### PR TITLE
Updated French translation

### DIFF
--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -865,4 +865,14 @@
     <string name="pref_cat_navbar_custom_key_title">Paramètres touche personnalisée</string>
     <string name="pref_navbar_custom_key_enable_title">Active la touche personnalisée</string>
 
+    <!-- Signal cluster settings -->
+    <string name="pref_cat_signal_cluster_title">Paramètres regroupés des signaux</string>
+    <string name="pref_signal_cluster_connection_state_title">Activer l\'état de la connexion</string>
+    <string name="pref_signal_cluster_connection_state_summary">Indique si l\'état de la connexion est partiel ou complet sur les icônes mobile et Wifi (redémarrage nécessaire)</string>
+    <string name="pref_signal_cluster_data_activity_title">Activer l\'activité de données</string>
+    <string name="pref_signal_cluster_data_activity_summary">Indique l\'activité des échanges de données sur les icônes mobile et Wifi (redémarrage nécessaire)</string>
+
+    <!-- Network mode tile: CDMA support -->
+    <string name="pref_network_mode_tile_cdma_title">Utiliser les modes réseau CDMA</string>
+
 </resources>


### PR DESCRIPTION
Statusbar Signal Cluster settings (KitKat only)
Network mode tile: option to use CDMA network modes instead of GSM
