### PR TITLE
Better abbreviation for minutes : "min"

### DIFF
--- a/res/xml/gravitybox.xml
+++ b/res/xml/gravitybox.xml
@@ -1535,7 +1535,7 @@
                 maximum="60"
                 interval="1"
                 monitorBoxEnabled="true"
-                monitorBoxUnit="m"
+                monitorBoxUnit="min"
                 android:defaultValue="10" />
 
         </PreferenceCategory>


### PR DESCRIPTION
IMHO, "min" stands for minutes abbreviation instead of "m". Otherwise it could translatable ?
