### PR TITLE
Updated French translation [KK]

### DIFF
--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -1002,4 +1002,14 @@
     <string name="pref_force_overflow_menu_button_title">Forcer le dépassement du bouton menu</string>
     <string name="pref_force_overflow_menu_button_summary">Nécessite un redémarrage</string>
 
+    <!-- Navbar: always on bottom -->
+    <string name="pref_navbar_always_on_bottom_title">Toujours en bas</string>
+    <string name="pref_navbar_always_on_bottom_summary">Force la barre de navigation à être en bas d\'écran en orientation paysage (nécessite un redémarrage)</string>
+
+    <!-- Summary for Home key long-press action disabled because of navring targets -->
+    <string name="pref_hwkey_home_longpress_disabled_summary">Ne peut pas être utilisé lorsque les cibles de la barre de navigation sont actives</string>
+
+    <!-- Navbar custom key: swap with menu key -->
+    <string name="pref_navbar_custom_key_swap_title">Intervertir avec la touche menu</string>
+
 </resources>


### PR DESCRIPTION
Navbar: option to make navbar always on bottom regardless orientation
Clearly indicate that home key long-press action cannot be used while
Navbar custom key: option to swap position with menu key
