### PR TITLE
Updated French translation [JB]

### DIFF
--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -1041,4 +1041,15 @@
     <string name="pref_qs_tile_span_disable_title">Désactiver l\'élargissement de touche</string>
     <string name="pref_qs_tile_span_disable_summary">Désactive l\'élargissement des touches utilisateur, luminosité, et paramètres en orientation paysage</string>
 
-</resources>
+    <!-- Force overflow menu button -->
+    <string name="pref_force_overflow_menu_button_title">Forcer le dépassement du bouton menu</string>
+    <string name="pref_force_overflow_menu_button_summary">Nécessite un redémarrage</string>
+
+    <!-- Navbar: always on bottom -->
+    <string name="pref_navbar_always_on_bottom_title">Toujours en bas</string>
+    <string name="pref_navbar_always_on_bottom_summary">Force la barre de navigation à être en bas d\'écran en orientation paysage (nécessite un redémarrage)</string>
+
+    <!-- Summary for Home key long-press action disabled because of navring targets -->
+    <string name="pref_hwkey_home_longpress_disabled_summary">Ne peut pas être utilisé lorsque les cibles de la barre de navigation sont actives</string>
+
+ </resources>


### PR DESCRIPTION
- ModViewConfig: option to force overflow menu button
- Clearly indicate that home key long-press action cannot be used while navbar ring targets are enabled
- Navbar: option to make navbar always on bottom regardless orientation
