### PR TITLE
TrafficMeter: get rid of double-check

### DIFF
--- a/src/com/ceco/kitkat/gravitybox/TrafficMeter.java
+++ b/src/com/ceco/kitkat/gravitybox/TrafficMeter.java
@@ -150,12 +150,7 @@ public class TrafficMeter extends TextView implements IconManagerListener {
 
     public void startTrafficUpdates() {
         if (mAttached && getConnectAvailable()) {
-            mTotalRxBytes = TrafficStats.getTotalRxBytes();
-            if (mTotalRxBytes == 0) {
-                // On some old devices, the traffic status will stick on 0B/s
-                // So let's check by another way
-                mTotalRxBytes = getTotalReceivedBytes();
-            }
+            mTotalRxBytes = getTotalReceivedBytes();
             mLastUpdateTime = SystemClock.elapsedRealtime();
             mTrafficBurstStartTime = Long.MIN_VALUE;
 
@@ -209,20 +204,8 @@ public class TrafficMeter extends TextView implements IconManagerListener {
                 return;
             }
 
-            long currentRxBytes = TrafficStats.getTotalRxBytes();
+            long currentRxBytes = getTotalReceivedBytes();
             long newBytes = currentRxBytes - mTotalRxBytes;
-
-            if (newBytes <= 0) {
-                // On some old devices, the traffic status will stick on 0B/s
-                // So let's check by another way
-                currentRxBytes = getTotalReceivedBytes();
-                newBytes = currentRxBytes - mTotalRxBytes;
-            }
-
-            if (newBytes < 0) {
-                currentRxBytes = 0;
-                newBytes = 0;
-            }
 
             if (mTrafficMeterHide && newBytes == 0) {
                 long trafficBurstBytes = currentRxBytes - mTrafficBurstStartBytes;


### PR DESCRIPTION
Hello, me again.
This tme you are able to merge this instead of cherry-picking.

According to test of mine and MoKee OpenSource's, this method has compatibility with most devices.

So, 
1. Get rid of old method
2. Always read from file
3. Fixed problems caused by double-check
