### PR TITLE
TrafficMeter: Fix display when disconnecting

### DIFF
--- a/src/com/ceco/kitkat/gravitybox/TrafficMeter.java
+++ b/src/com/ceco/kitkat/gravitybox/TrafficMeter.java
@@ -251,7 +251,7 @@ public class TrafficMeter extends TextView implements IconManagerListener {
                 }
             }
 
-            mTotalRxBytes = currentRxBytes;
+            mTotalRxBytes = disconnected ? mTotalRxBytes : currentRxBytes;
             mLastUpdateTime = SystemClock.elapsedRealtime();
             getHandler().postDelayed(mRunnable, 1000);
         }

--- a/src/com/ceco/kitkat/gravitybox/TrafficMeter.java
+++ b/src/com/ceco/kitkat/gravitybox/TrafficMeter.java
@@ -207,8 +207,16 @@ public class TrafficMeter extends TextView implements IconManagerListener {
             long currentRxBytes = getTotalReceivedBytes();
             long newBytes = currentRxBytes - mTotalRxBytes;
 
+            boolean disconnected = false;
+            if (newBytes < 0) {
+                // It's impossible to get a speed under 0
+                currentRxBytes = 0;
+                newBytes = 0;
+                disconnected = true;
+            }
+
             if (mTrafficMeterHide && newBytes == 0) {
-                long trafficBurstBytes = currentRxBytes - mTrafficBurstStartBytes;
+                long trafficBurstBytes = disconnected ? mTotalRxBytes - mTrafficBurstStartBytes : currentRxBytes - mTrafficBurstStartBytes;
 
                 if (trafficBurstBytes != 0 && mTrafficMeterSummaryTime != 0) {
                     setText(formatTraffic(trafficBurstBytes, false));


### PR DESCRIPTION
I'm sorry to say that my last patch included a bug that the speed display would be like "-400000B/s" when disconnecting. This patch will fix the bug.

What's new:
1. Added logic to set speed to zero if disconnecting
2. Process the total burst bytes in another way when disconnecting
