### PR TITLE
Added tap vs hold on clear recent button mode changer

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -770,4 +770,16 @@
         <item>2</item>
     </string-array>
 
+    <string-array name="pref_translucent_decor_entries" translatable="false">
+        <item>@string/pref_translucent_decor_default</item>
+        <item>@string/pref_translucent_decor_enabled</item>
+        <item>@string/pref_translucent_decor_disabled</item>
+    </string-array>
+
+    <string-array name="pref_translucent_decor_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+
 </resources>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -782,4 +782,14 @@
         <item>2</item>
     </string-array>
 
+    <string-array name="pref_clear_recents_mode_entries" translatable="false">
+        <item>@string/pref_clear_recents_mode_0</item>
+        <item>@string/pref_clear_recents_mode_1</item>
+    </string-array>
+
+	<string-array name="pref_clear_recents_mode_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+    </string-array>
+
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1045,4 +1045,9 @@
     <string name="pref_translucent_decor_enabled">Enabled</string>
     <string name="pref_translucent_decor_disabled">Disabled</string>
 
+    <!--  Clear recents modes -->
+    <string name="pref_clear_recents_mode_title">Clear all recent tasks behaviour</string>
+    <string name="pref_clear_recents_mode_0">Tap to clear all, long-press to clear all but current</string>
+    <string name="pref_clear_recents_mode_1">Tap to clear all but current, long-press to clear all</string>
+
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1046,7 +1046,7 @@
     <string name="pref_translucent_decor_disabled">Disabled</string>
 
     <!--  Clear recents modes -->
-    <string name="pref_clear_recents_mode_title">Clear all recent tasks behaviour</string>
+    <string name="pref_clear_recents_mode_title">Clear all recent tasks behavior</string>
     <string name="pref_clear_recents_mode_0">Tap to clear all, long-press to clear all but current</string>
     <string name="pref_clear_recents_mode_1">Tap to clear all but current, long-press to clear all</string>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -365,12 +365,6 @@
     <string name="pref_holo_bg_dither_title">Dithered Holo background</string>
     <string name="pref_holo_bg_dither_summary">Replaces standard Holo background with dithered one to suppress color banding (requires reboot)</string>
 
-    <!-- Translucent decor options -->
-    <string name="pref_translucent_decor_title">Enable Translucent Decor</string>
-    <string name="pref_translucent_decor_default">System Default</string>
-    <string name="pref_translucent_decor_enabled">Enabled</string>
-    <string name="pref_translucent_decor_disabled">Disabled</string>
-
     <!-- Disable navigation keys for pie -->
     <string name="pref_hwkeys_disable_title">Disable navigation keys</string>
     <string name="pref_hwkeys_disable_summary">Disables single-tap on keys while Pie Controls are enabled</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -365,6 +365,12 @@
     <string name="pref_holo_bg_dither_title">Dithered Holo background</string>
     <string name="pref_holo_bg_dither_summary">Replaces standard Holo background with dithered one to suppress color banding (requires reboot)</string>
 
+    <!-- Translucent decor options -->
+    <string name="pref_translucent_decor_title">Enable Translucent Decor</string>
+    <string name="pref_translucent_decor_default">System Default</string>
+    <string name="pref_translucent_decor_enabled">Enabled</string>
+    <string name="pref_translucent_decor_disabled">Disabled</string>
+
     <!-- Disable navigation keys for pie -->
     <string name="pref_hwkeys_disable_title">Disable navigation keys</string>
     <string name="pref_hwkeys_disable_summary">Disables single-tap on keys while Pie Controls are enabled</string>

--- a/res/xml/gravitybox.xml
+++ b/res/xml/gravitybox.xml
@@ -1181,7 +1181,7 @@
             android:title="@string/pref_translucent_decor_title"
             android:entries="@array/pref_translucent_decor_entries"
             android:entryValues="@array/pref_translucent_decor_values"
-            android:defaultValue="default" />
+            android:defaultValue="0" />
 
     </PreferenceScreen>
 

--- a/res/xml/gravitybox.xml
+++ b/res/xml/gravitybox.xml
@@ -1587,6 +1587,13 @@
                 android:defaultValue="53" />
 
             <ListPreference 
+                android:key="pref_clear_recents_mode"
+                android:title="@string/pref_clear_recents_mode_title"
+                android:entries="@array/pref_clear_recents_mode_entries"
+                android:entryValues="@array/pref_clear_recents_mode_values"
+                android:defaultValue="0" />
+
+            <ListPreference 
                 android:key="pref_rambar"
                 android:title="@string/pref_rambar_title"
                 android:entries="@array/rambar_entries"

--- a/res/xml/gravitybox.xml
+++ b/res/xml/gravitybox.xml
@@ -1176,6 +1176,13 @@
             android:summary="@string/pref_button_backlight_notifications_summary"
             android:defaultValue="false" />
 
+        <ListPreference
+            android:key="pref_translucent_decor"
+            android:title="@string/pref_translucent_decor_title"
+            android:entries="@array/pref_translucent_decor_entries"
+            android:entryValues="@array/pref_translucent_decor_values"
+            android:defaultValue="default" />
+
     </PreferenceScreen>
 
     <PreferenceScreen 

--- a/src/com/ceco/kitkat/gravitybox/GravityBoxSettings.java
+++ b/src/com/ceco/kitkat/gravitybox/GravityBoxSettings.java
@@ -119,6 +119,7 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
     public static final int VOL_KEY_CURSOR_CONTROL_ON_REVERSE = 2;
 
     public static final String PREF_KEY_RECENTS_CLEAR_ALL = "pref_recents_clear_all2";
+    public static final String PREF_KEY_CLEAR_RECENTS_MODE = "pref_clear_recents_mode";
     public static final String PREF_KEY_RAMBAR = "pref_rambar";
     public static final String PREF_KEY_RECENTS_CLEAR_MARGIN_TOP = "pref_recent_clear_margin_top";
     public static final String PREF_KEY_RECENTS_CLEAR_MARGIN_BOTTOM = "pref_recent_clear_margin_bottom";
@@ -880,6 +881,7 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
         private ListPreference mPrefPieAppLongpress;
         private CheckBoxPreference mPrefGbThemeDark;
         private ListPreference mPrefRecentClear;
+        private ListPreference mPrefClearRecentMode;
         private ListPreference mPrefRambar;
         private PreferenceScreen mPrefCatPhone;
         private SeekBarPreference mPrefBrightnessMin;
@@ -1088,6 +1090,7 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
             mPrefGbThemeDark.setChecked(file.exists());
 
             mPrefRecentClear = (ListPreference) findPreference(PREF_KEY_RECENTS_CLEAR_ALL);
+            mPrefClearRecentMode = (ListPreference) findPreference(PREF_KEY_CLEAR_RECENTS_MODE);
             mPrefRambar = (ListPreference) findPreference(PREF_KEY_RAMBAR);
 
             mPrefCatPhone = (PreferenceScreen) findPreference(PREF_CAT_KEY_PHONE);
@@ -1541,6 +1544,10 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
 
             if (key == null || key.equals(PREF_KEY_RECENTS_CLEAR_ALL)) {
                 mPrefRecentClear.setSummary(mPrefRecentClear.getEntry());
+            }
+
+            if (key == null || key.equals(PREF_KEY_CLEAR_RECENTS_MODE)) {
+                mPrefClearRecentMode.setSummary(mPrefClearRecentMode.getEntry());
             }
 
             if (key == null || key.equals(PREF_KEY_RAMBAR)) {

--- a/src/com/ceco/kitkat/gravitybox/GravityBoxSettings.java
+++ b/src/com/ceco/kitkat/gravitybox/GravityBoxSettings.java
@@ -889,6 +889,7 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
         private PreferenceScreen mPrefCatDisplay;
         private PreferenceScreen mPrefCatBrightness;
         private ListPreference mPrefCrtOff;
+        private ListPreference mPrefTranclucentDecor;
         private PreferenceScreen mPrefCatMedia;
         private CheckBoxPreference mPrefSafeMediaVolume;
         private ListPreference mPrefExpandedDesktop;
@@ -1110,6 +1111,7 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
             mPrefVolumePanelFullyExpandable = (CheckBoxPreference) findPreference(PREF_KEY_VOLUME_PANEL_FULLY_EXPANDABLE);
             mPrefVolumePanelAutoexpand = (CheckBoxPreference) findPreference(PREF_KEY_VOLUME_PANEL_AUTOEXPAND);
             mPrefVolumePanelTimeout = (ListPreference) findPreference(PREF_KEY_VOLUME_PANEL_TIMEOUT);
+            mPrefTranclucentDecor =  (ListPreference) findPreference(PREF_KEY_TRANSLUCENT_DECOR);
 
             mPrefExpandedDesktop = (ListPreference) findPreference(PREF_KEY_EXPANDED_DESKTOP);
 
@@ -1634,6 +1636,10 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
 
             if (key == null || key.equals(PREF_KEY_CRT_OFF_EFFECT)) {
                 mPrefCrtOff.setSummary(mPrefCrtOff.getEntry());
+            }
+            
+            if (key == null || key.equals(PREF_KEY_TRANSLUCENT_DECOR)) {
+            	mPrefTranclucentDecor.setSummary(mPrefTranclucentDecor.getEntry());
             }
 
             if (key == null || key.equals(PREF_KEY_LAUNCHER_DESKTOP_GRID_ROWS)) {

--- a/src/com/ceco/kitkat/gravitybox/GravityBoxSettings.java
+++ b/src/com/ceco/kitkat/gravitybox/GravityBoxSettings.java
@@ -229,6 +229,7 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
     public static final String PREF_KEY_AUTOBRIGHTNESS = "pref_autobrightness";
     public static final String PREF_KEY_HOLO_BG_SOLID_BLACK = "pref_holo_bg_solid_black";
     public static final String PREF_KEY_HOLO_BG_DITHER = "pref_holo_bg_dither";
+    public static final String PREF_KEY_TRANSLUCENT_DECOR = "pref_translucent_decor";
 
     public static final String PREF_CAT_KEY_MEDIA = "pref_cat_media";
     public static final String PREF_KEY_VOL_MUSIC_CONTROLS = "pref_vol_music_controls";
@@ -622,6 +623,7 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
             PREF_KEY_MUSIC_VOLUME_STEPS,
             PREF_KEY_HOLO_BG_SOLID_BLACK,
             PREF_KEY_HOLO_BG_DITHER,
+            PREF_KEY_TRANSLUCENT_DECOR,
             PREF_KEY_SCREEN_DIM_LEVEL,
             PREF_KEY_BRIGHTNESS_MASTER_SWITCH,
             PREF_KEY_NAVBAR_OVERRIDE,

--- a/src/com/ceco/kitkat/gravitybox/GravityBoxSettings.java
+++ b/src/com/ceco/kitkat/gravitybox/GravityBoxSettings.java
@@ -1637,13 +1637,9 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
             if (key == null || key.equals(PREF_KEY_CRT_OFF_EFFECT)) {
                 mPrefCrtOff.setSummary(mPrefCrtOff.getEntry());
             }
-            
-            if (key == null || key.equals(PREF_KEY_TRANSLUCENT_DECOR)) {
-            	mPrefTranclucentDecor.setSummary(mPrefTranclucentDecor.getEntry());
-            }
 
             if (key == null || key.equals(PREF_KEY_TRANSLUCENT_DECOR)) {
-                mPrefTranclucentDecor.setSummary(mPrefTranclucentDecor.getEntry());
+            	mPrefTranclucentDecor.setSummary(mPrefTranclucentDecor.getEntry());
             }
 
             if (key == null || key.equals(PREF_KEY_LAUNCHER_DESKTOP_GRID_ROWS)) {

--- a/src/com/ceco/kitkat/gravitybox/GravityBoxSettings.java
+++ b/src/com/ceco/kitkat/gravitybox/GravityBoxSettings.java
@@ -1639,7 +1639,7 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
             }
 
             if (key == null || key.equals(PREF_KEY_TRANSLUCENT_DECOR)) {
-            	mPrefTranclucentDecor.setSummary(mPrefTranclucentDecor.getEntry());
+                mPrefTranclucentDecor.setSummary(mPrefTranclucentDecor.getEntry());
             }
 
             if (key == null || key.equals(PREF_KEY_LAUNCHER_DESKTOP_GRID_ROWS)) {

--- a/src/com/ceco/kitkat/gravitybox/ModClearAllRecents.java
+++ b/src/com/ceco/kitkat/gravitybox/ModClearAllRecents.java
@@ -54,6 +54,7 @@ public class ModClearAllRecents {
 
     private static XSharedPreferences mPrefs;
     private static ImageView mRecentsClearButton;
+    private static int mClearRecentsMode;
 
     // RAM bar
     private static TextView mBackgroundProcessText;
@@ -137,7 +138,7 @@ public class ModClearAllRecents {
                             ViewGroup mRecentsContainer = (ViewGroup) XposedHelpers.getObjectField(
                                     param.thisObject, "mRecentsContainer");
                             // passing null parameter in this case is our action flag to remove all views
-                            mPreserveCurrentTask = false;
+                            mPreserveCurrentTask = (mClearRecentsMode == 1);
                             mRecentsContainer.removeViewInLayout(null);
                         }
                     });
@@ -147,7 +148,7 @@ public class ModClearAllRecents {
                             ViewGroup mRecentsContainer = (ViewGroup) XposedHelpers.getObjectField(
                                     param.thisObject, "mRecentsContainer");
                             // passing null parameter in this case is our action flag to remove all views
-                            mPreserveCurrentTask = true;
+                            mPreserveCurrentTask = (mClearRecentsMode == 0);
                             mRecentsContainer.removeViewInLayout(null);
                             return true;
                         }
@@ -230,6 +231,8 @@ public class ModClearAllRecents {
 
     private static void updateButtonLayout(View container) {
         if (mRecentsClearButton == null) return;
+        
+        mClearRecentsMode = Integer.valueOf(mPrefs.getString(GravityBoxSettings.PREF_KEY_CLEAR_RECENTS_MODE, "0"));
 
         final Context context = mRecentsClearButton.getContext();
         int gravity = Integer.valueOf(mPrefs.getString(

--- a/src/com/ceco/kitkat/gravitybox/SystemWideResources.java
+++ b/src/com/ceco/kitkat/gravitybox/SystemWideResources.java
@@ -32,7 +32,7 @@ public class SystemWideResources {
 
             int translucentDecor = Integer.valueOf(prefs.getString(GravityBoxSettings.PREF_KEY_TRANSLUCENT_DECOR, "0"));
             if (translucentDecor != 0) {
-            	XResources.setSystemWideReplacement("android", "bool", "config_enableTranslucentDecor", translucentDecor == 1);
+                XResources.setSystemWideReplacement("android", "bool", "config_enableTranslucentDecor", translucentDecor == 1);
             }
 
             boolean holoBgDither = prefs.getBoolean(GravityBoxSettings.PREF_KEY_HOLO_BG_DITHER, false);

--- a/src/com/ceco/kitkat/gravitybox/SystemWideResources.java
+++ b/src/com/ceco/kitkat/gravitybox/SystemWideResources.java
@@ -35,11 +35,6 @@ public class SystemWideResources {
             	XResources.setSystemWideReplacement("android", "bool", "config_enableTranslucentDecor", translucentDecor == 1);
             }
 
-            int translucentDecor = Integer.valueOf(prefs.getString(GravityBoxSettings.PREF_KEY_TRANSLUCENT_DECOR, "0"));
-            if (translucentDecor != 0) {
-                XResources.setSystemWideReplacement("android", "bool", "config_enableTranslucentDecor", translucentDecor == 1);
-            }
-
             boolean holoBgDither = prefs.getBoolean(GravityBoxSettings.PREF_KEY_HOLO_BG_DITHER, false);
             if (prefs.getBoolean(GravityBoxSettings.PREF_KEY_HOLO_BG_SOLID_BLACK, false)) {
                 XResources.setSystemWideReplacement(

--- a/src/com/ceco/kitkat/gravitybox/SystemWideResources.java
+++ b/src/com/ceco/kitkat/gravitybox/SystemWideResources.java
@@ -29,7 +29,7 @@ public class SystemWideResources {
             Resources systemRes = XResources.getSystem();
 
             XModuleResources modRes = XModuleResources.createInstance(GravityBox.MODULE_PATH, null);
-            
+
             int translucentDecor = Integer.valueOf(prefs.getString(GravityBoxSettings.PREF_KEY_TRANSLUCENT_DECOR, "0"));
             if (translucentDecor != 0) {
             	XResources.setSystemWideReplacement("android", "bool", "config_enableTranslucentDecor", translucentDecor == 1);

--- a/src/com/ceco/kitkat/gravitybox/SystemWideResources.java
+++ b/src/com/ceco/kitkat/gravitybox/SystemWideResources.java
@@ -29,6 +29,11 @@ public class SystemWideResources {
             Resources systemRes = XResources.getSystem();
 
             XModuleResources modRes = XModuleResources.createInstance(GravityBox.MODULE_PATH, null);
+            
+            int translucentDecor = Integer.valueOf(prefs.getString(GravityBoxSettings.PREF_KEY_TRANSLUCENT_DECOR, "0"));
+            if (translucentDecor != 0) {
+            	XResources.setSystemWideReplacement("android", "bool", "config_enableTranslucentDecor", translucentDecor == 1);
+            }
 
             boolean holoBgDither = prefs.getBoolean(GravityBoxSettings.PREF_KEY_HOLO_BG_DITHER, false);
             if (prefs.getBoolean(GravityBoxSettings.PREF_KEY_HOLO_BG_SOLID_BLACK, false)) {


### PR DESCRIPTION
Allows a user to swap the mode of the tap vs hold on the clear recent button. Defaults to current functionality of tap to clear all and hold to clear all but current.

Sentence structure in mode descriptions could use some work as they just don't sound quite right, but not sure what to change either.
