### PR TITLE
Updated French translation [JB]

### DIFF
--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -910,7 +910,7 @@
     <string name="pref_cat_power_other_title">Autre</string>
 
     <!-- Advanced reboot menu: Allow on lockscreen -->
-    <string name="pref_reboot_allow_on_lockscreen_title">Actif sur écran de déverrouillage</string>
+    <string name="pref_reboot_allow_on_lockscreen_title">Redémarrage autorisé depuis l\'écran de déverrouillage</string>
 
     <!-- Data traffic monitor enhancements -->
     <string name="pref_data_traffic_inactivity_mode_title">Mode d\'inactivité</string>
@@ -1047,5 +1047,63 @@
 
      <!-- Navbar custom key: swap with menu key -->
     <string name="pref_navbar_custom_key_swap_title">Intervertir avec la touche menu</string>
+
+    <!-- Smart Radio -->
+    <string name="smart_radio_action_undefined">Non défini</string>
+    <string name="pref_cat_smart_radio_title">Ondes radio intelligentes</string>
+    <string name="pref_smart_radio_enable_summary">Cela va automatiquement commuter vos paramètres de ROM radio soit en mode économie d\'énergie défini par l\'utilisateur soit en mode normal,
+        selon l\'état des connexions de données mobiles et Wifi (redémarrage nécessaire)</string>
+    <string name="pref_smart_radio_normal_mode_title">Mode réseau normal</string>
+    <string name="pref_smart_radio_power_saving_mode_title">Mode réseau économie d\'énergie</string>
+    <string name="pref_smart_radio_screen_off_title">Lorsque l\'écran s\'éteint</string>
+    <string name="pref_smart_radio_screen_off_summary">Active le mode économie d\'énergie lorsque l\'écran s\'éteint sans tenir compte si les données mobiles sont activées ou non</string>
+    <string name="pref_smart_radio_ignore_locked_title">Ignorer si verrouillé</string>
+    <string name="pref_smart_radio_ignore_locked_summary">Lorsque l\'écran s\'allume, le mode économie d\'énergie ne sera pas désactivé avant que l\'appareil ne soit déverrouillé</string>
+    <string name="pref_smart_radio_mode_change_delay_title">Délai pour le changement de mode réseau</string>
+    <string name="pref_smart_radio_mode_change_delay_summary">Retarde le changement de mode réseau par le nombre de secondes indiqué</string>
+
+    <!-- Lockscreen: custom carrier text -->
+    <string name="pref_lockscreen_carrier_text_title">Personnaliser le texte du nom d\'opérateur</string>
+    <string name="carrier_text_default">Par défaut</string>
+    <string name="carrier_text_empty">Rien</string>
+
+    <!-- Battery charged sound -->
+    <string name="pref_battery_charged_sound_title">Son pour batterie chargée</string>
+    <string name="pref_battery_charged_sound_summary">Joue un son lorsque la batterie est complètement chargée</string>
+
+    <!-- Pie long-press actions -->
+    <string name="pref_cat_pie_long_press_title">Actions avec appui long</string>
+    <string name="pref_pie_back_longpress_title">Touche Retour</string>
+    <string name="pref_pie_home_longpress_title">Touche Home</string>
+    <string name="pref_pie_recents_longpress_title">Touche Appli Récentes</string>
+    <string name="pref_pie_search_longpress_title">Touche Rechercher</string>
+    <string name="pref_pie_menu_longpress_title">Touche Menu</string>
+    <string name="pref_pie_app_longpress_title">Touche Lanceur d\'Appli</string>
+
+    <!-- Pulse notification delay -->
+    <string name="pref_pulse_notification_delay_title">Délai pulsation de notification</string>
+    <string name="pref_pulse_notification_delay_summary">Redémarrace nécessaire</string>
+
+    <!--  Clear recents modes -->
+    <string name="pref_clear_recents_mode_title">Comportement nettoyage de toutes les tâches récentes</string>
+    <string name="pref_clear_recents_mode_0">Taper pour tout nettoyer, appui long pour tout nettoyer sauf tâche en cours</string>
+    <string name="pref_clear_recents_mode_1">Taper pour tout nettoyer sauf tâche en cours, appui long pour tout nettoyer</string>
+
+    <!-- Powe menu: disable on lockscreen -->
+    <string name="pref_powermenu_disable_on_lockscreen_title">Désactiver le menu de redémarrage depuis écran de déverrouillage</string>
+
+    <!-- Extended force overflow menu button option -->
+    <string name="overflow_menu_default">Valeur système par défaut</string>
+    <string name="overflow_menu_enabled">Forcer l\'activation</string>
+    <string name="overflow_menu_disabled">Forcer la désactivation</string>
+
+    <!-- Key Action: Take screenshot -->
+    <string name="hwkey_action_screenshot">Prendre une capture d\'écran</string>
+
+    <!-- Key Action: Show volume panel -->
+    <string name="hwkey_action_volume_panel">Afficher le panneau de volume</string>
+
+    <!-- Blur effect intensity -->
+    <string name="pref_lockscreen_bg_blur_intensity_title">Intensité de l\'effet de floutage</string>
 
 </resources>


### PR DESCRIPTION
Smart radio: option to ignore mode switching while keyguard is locked
Smart Radio: added option for delaying network mode change
Power tweaks: added option for battery charged sound
Pie Controls: implemented long-press support for pie buttons
Key Actions: added Take screenshot action
Key Actions: added action for showing volume panel
LED: option to set pulse notification delay
Added setting to change the tap vs long-press modes of clearing recent activities
Lockscreen: added option for custom carrier text
ModPowerMenu: more clear title for Allow reboot on lockscreen
ModPowerMenu: option to disable power menu on lockscreen
ModViewConfig: extended option for overflow menu button
Lockscreen blur: option to specify blur effect intensity
