### PR TITLE
Updated French translation [JB]

### DIFF
--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -1106,4 +1106,56 @@
     <!-- Blur effect intensity -->
     <string name="pref_lockscreen_bg_blur_intensity_title">Intensité de l\'effet de floutage</string>
 
+    <!-- Smart radio: independent delay for screen off power save event -->
+    <string name="pref_smart_radio_screen_off_delay_title">Économie d\'énergie différée</string>
+    <string name="pref_smart_radio_screen_off_delay_summary">Diffère la bascule en mode économie d\'énergie lorsque l\'écran s\'éteint. 
+        Remplace le délai par défaut pour le changement de mode réseau si la valeur n\'est pas nulle</string>
+
+    <!-- Lockscreen: secondary custom carrier text (MTK only) -->
+    <string name="pref_lockscreen_carrier2_text_title">Personnaliser le texte du nom d\'opérateur secondaire</string>
+
+    <!-- Backup and restore settings -->
+    <string name="pref_settings_backup_title">Sauvegarder les paramètres</string>
+    <string name="pref_settings_restore_title">Restaurer les paramètres</string>
+    <string name="settings_backup_failed">La sauvegarde a échoué</string>
+    <string name="settings_backup_no_prefs">Fichier de préférences introuvable</string>
+    <string name="settings_backup_success">La sauvegarde a été réalisée</string>
+    <string name="settings_restore_no_backup">Il n\'y a pas de sauvegarde à restaurer</string>
+    <string name="settings_restore_confirm">Vos préférences actuelles vont être remplacées. Êtes-vous sûr ?</string>
+    <string name="settings_restore_failed">La restauration a échoué</string>
+    <string name="settings_restore_success">La restauration a été effectuée</string>
+    <string name="settings_restore_reboot">S\'il vous plait, redémarrer votre appareil</string>
+
+    <!-- Web service client strings -->
+    <string name="wsc_hash_creation_failed">Erreur dans la création de clé de contrôle spécifique à l\'appli</string>
+    <string name="wsc_parse_response_error">Erreur dans l\'analyse des données reçues par le service Web</string>
+    <string name="wsc_hash_invalid">Le service Web refuse de communiquer à cause d\'une clé de contrôle discordante. Cela arrive typiquement lorsque
+        vous utilisez une version non officielle ou si l\'APK de GravityBox a été modifié par une tierce partie</string>
+    <string name="wsc_please_wait">Attendez s\'il vous plaît&#8230;</string>
+    <string name="wsc_error">Erreur de communication avec le service Web : %s</string>
+    <string name="wsc_task_cancelled">Opération du service Web annulée</string>
+
+    <!-- Transaction verification -->
+    <string name="wsc_trans_parse_response_error">Erreur dans l\'analyse des données de la transaction obtenues par le service Web</string>
+    <string name="wsc_trans_valid">Vérification du n° de transaction unique réussie. Les éléments de la version Premium seront accessibles après le redémarrage de GravityBox</string>
+    <string name="wsc_trans_invalid">N° de transaction unique introuvable</string>
+    <string name="wsc_trans_violation">Le n° de transaction unique a été enregistré trop souvent. Contactez le développeur de GravityBox</string>
+    <string name="wsc_trans_blocked">Le n° de transaction unique a été bloqué. Contactez le développeur de GravityBox</string>
+    <string name="pref_trans_verification_title">N° de transaction unique PayPal</string>
+    <string name="pref_trans_verification_summary">Dans le cas où vous avez fait une donation, vous pouvez saisir le n° de transaction unique Paypal pour avoir accès aux éléments de la version Premium</string>
+    <string name="wsc_trans_required_summary">Cet élément nécessite un n° de transaction unique Paypal</string>
+
+    <!-- Pie: disable system info -->
+    <string name="pref_pie_sysinfo_disable_title">Désactiver les infos système</string>
+
+    <!-- Pie: long press delay -->
+    <string name="pref_pie_longpress_delay_title">Délai appui long</string>
+    <string name="pie_longpress_delay_default">Valeur système par défaut</string>
+
+    <!-- GB Actions: Launcher drawer shortcut -->
+    <string name="shortcut_launcher_drawer">Tiroir de lancement d\'appli</string>
+
+    <!-- Key Actions: Show launcher drawer -->
+    <string name="hwkey_action_launcher_drawer">Afficher le tiroir de lancement d\'appli</string>
+
 </resources>


### PR DESCRIPTION
Notification drawer style: custom carrier text support for MTK
Added very basic backup/restore settings feature
Let's do some monetizing
Smart Radio: option to delay power saving mode after screen turns off
Pie: option to disable system info slice
Pie: added option for adjusting long-press delay
GB Actions: added shortcut for opening launcher's app drawer
Key actions: added action for opening launcher's app drawer
