### PR TITLE
add intent extra for setting extended desktop on or off

### DIFF
--- a/src/com/ceco/kitkat/gravitybox/ModHwKeys.java
+++ b/src/com/ceco/kitkat/gravitybox/ModHwKeys.java
@@ -279,7 +279,7 @@ public class ModHwKeys {
                 mExpandedDesktopMode = intent.getIntExtra(
                         GravityBoxSettings.EXTRA_ED_MODE, GravityBoxSettings.ED_DISABLED);
             } else if (action.equals(ACTION_TOGGLE_EXPANDED_DESKTOP) && mPhoneWindowManager != null) {
-                toggleExpandedDesktop();
+                toggleExpandedDesktop(value);
             } else if (action.equals(ScreenRecordingService.ACTION_TOGGLE_SCREEN_RECORDING)) {
                 toggleScreenRecording();
             } else if (action.equals(GravityBoxSettings.ACTION_PREF_NAVBAR_CHANGED)) {
@@ -1005,7 +1005,7 @@ public class ModHwKeys {
         } else if (action == GravityBoxSettings.HWKEY_ACTION_MENU) {
             injectKey(KeyEvent.KEYCODE_MENU);
         } else if (action == GravityBoxSettings.HWKEY_ACTION_EXPANDED_DESKTOP) {
-            toggleExpandedDesktop();
+            toggleExpandedDesktop(0);
         } else if (action == GravityBoxSettings.HWKEY_ACTION_TORCH) {
             toggleTorch();
         } else if (action == GravityBoxSettings.HWKEY_ACTION_APP_LAUNCHER) {
@@ -1245,7 +1245,7 @@ public class ModHwKeys {
         });
     }
 
-    private static void toggleExpandedDesktop() {
+    private static void toggleExpandedDesktop(final int value) {
         Handler handler = (Handler) XposedHelpers.getObjectField(mPhoneWindowManager, "mHandler");
         if (handler == null) return;
 
@@ -1259,11 +1259,22 @@ public class ModHwKeys {
                     if (edMode == GravityBoxSettings.ED_DISABLED) {
                         Toast.makeText(mContext, mStrExpandedDesktopDisabled, Toast.LENGTH_SHORT).show();
                     } else {
-                        final int edState = Settings.Global.getInt(resolver,
-                                ModExpandedDesktop.SETTING_EXPANDED_DESKTOP_STATE, 0);
-                        Settings.Global.putInt(resolver, 
-                                ModExpandedDesktop.SETTING_EXPANDED_DESKTOP_STATE,
-                                (edState == 1) ? 0 : 1);
+                    	if (value == GravityBoxSettings.HWKEY_ACTION_DEFAULT) {
+	                        final int edState = Settings.Global.getInt(resolver,
+	                                ModExpandedDesktop.SETTING_EXPANDED_DESKTOP_STATE, 0);
+	                        Settings.Global.putInt(resolver, 
+	                                ModExpandedDesktop.SETTING_EXPANDED_DESKTOP_STATE,
+	                                (edState == 1) ? 0 : 1);
+                    	} else {
+                    		// action = "gravitybox.intent.action.TOGGLE_EXPANDED_DESKTOP"
+                    		// extra = "hwKeyValue:0" (ED toggle)
+                    		// extra = "hwKeyValue:1" (ED on)
+                    		// extra = "hwKeyValue:-1" (ED off), (any value not 0 or 1),
+                    		// no extra = (ED toggle, like GB shortcut)
+                        	Settings.Global.putInt(resolver, 
+	                                ModExpandedDesktop.SETTING_EXPANDED_DESKTOP_STATE,
+	                                (value == 1) ? 0 : 1);                    		
+                    	}
                     }
                 } catch (Throwable t) {
                         XposedBridge.log(t);


### PR DESCRIPTION
With current GravityBox, we can toggle ED(expanded desktop) using a shortcut.

In normal usage, this toggling is OK, because human eyes can see current desktop's expended state.

But in a script like Tasker, which is an automatation app, we want to set ED to on or off expicitly.

So this INTENT method is only for advanced(?) users.

Intent usage is as below,
    action = "gravitybox.intent.action.TOGGLE_EXPANDED_DESKTOP" ( == predefined GD shortcut action )
    extra = "hwKeyValue:0" (ED toggle)
    extra = "hwKeyValue:1" (ED on)
    extra = "hwKeyValue:-1" (ED off), (any value not 0 or 1),
    no extra = (ED toggle, like GB shortcut)

I tried as little modification as possible, so used predifined hwKeyValue integer extra.

I'm not good at git system, it's my FIRST pull request, so I don't know my uploading(?) is right.
