### PR TITLE
User can enter a hex-code string into GB's varous intents' extra fields.

### DIFF
--- a/src/com/ceco/kitkat/gravitybox/ModHwKeys.java
+++ b/src/com/ceco/kitkat/gravitybox/ModHwKeys.java
@@ -279,7 +279,7 @@ public class ModHwKeys {
                 mExpandedDesktopMode = intent.getIntExtra(
                         GravityBoxSettings.EXTRA_ED_MODE, GravityBoxSettings.ED_DISABLED);
             } else if (action.equals(ACTION_TOGGLE_EXPANDED_DESKTOP) && mPhoneWindowManager != null) {
-                toggleExpandedDesktop();
+                toggleExpandedDesktop(value);
             } else if (action.equals(ScreenRecordingService.ACTION_TOGGLE_SCREEN_RECORDING)) {
                 toggleScreenRecording();
             } else if (action.equals(GravityBoxSettings.ACTION_PREF_NAVBAR_CHANGED)) {
@@ -1005,7 +1005,7 @@ public class ModHwKeys {
         } else if (action == GravityBoxSettings.HWKEY_ACTION_MENU) {
             injectKey(KeyEvent.KEYCODE_MENU);
         } else if (action == GravityBoxSettings.HWKEY_ACTION_EXPANDED_DESKTOP) {
-            toggleExpandedDesktop();
+            toggleExpandedDesktop(0);
         } else if (action == GravityBoxSettings.HWKEY_ACTION_TORCH) {
             toggleTorch();
         } else if (action == GravityBoxSettings.HWKEY_ACTION_APP_LAUNCHER) {
@@ -1245,7 +1245,7 @@ public class ModHwKeys {
         });
     }
 
-    private static void toggleExpandedDesktop() {
+    private static void toggleExpandedDesktop(final int value) {
         Handler handler = (Handler) XposedHelpers.getObjectField(mPhoneWindowManager, "mHandler");
         if (handler == null) return;
 
@@ -1259,11 +1259,22 @@ public class ModHwKeys {
                     if (edMode == GravityBoxSettings.ED_DISABLED) {
                         Toast.makeText(mContext, mStrExpandedDesktopDisabled, Toast.LENGTH_SHORT).show();
                     } else {
-                        final int edState = Settings.Global.getInt(resolver,
-                                ModExpandedDesktop.SETTING_EXPANDED_DESKTOP_STATE, 0);
-                        Settings.Global.putInt(resolver, 
-                                ModExpandedDesktop.SETTING_EXPANDED_DESKTOP_STATE,
-                                (edState == 1) ? 0 : 1);
+                    	if (value == GravityBoxSettings.HWKEY_ACTION_DEFAULT) {
+	                        final int edState = Settings.Global.getInt(resolver,
+	                                ModExpandedDesktop.SETTING_EXPANDED_DESKTOP_STATE, 0);
+	                        Settings.Global.putInt(resolver, 
+	                                ModExpandedDesktop.SETTING_EXPANDED_DESKTOP_STATE,
+	                                (edState == 1) ? 0 : 1);
+                    	} else {
+                    		// action = "gravitybox.intent.action.TOGGLE_EXPANDED_DESKTOP"
+                    		// extra = "hwKeyValue:0" (ED toggle)
+                    		// extra = "hwKeyValue:1" (ED on)
+                    		// extra = "hwKeyValue:-1" (ED off), (any value not 0 or 1),
+                    		// no extra = (ED toggle, like GB shortcut)
+                        	Settings.Global.putInt(resolver, 
+	                                ModExpandedDesktop.SETTING_EXPANDED_DESKTOP_STATE,
+	                                (value == 1) ? 0 : 1);                    		
+                    	}
                     }
                 } catch (Throwable t) {
                         XposedBridge.log(t);

--- a/src/com/ceco/kitkat/gravitybox/ModNavigationBar.java
+++ b/src/com/ceco/kitkat/gravitybox/ModNavigationBar.java
@@ -147,18 +147,33 @@ public class ModNavigationBar {
                     setCustomKeyVisibility();
                 }
                 if (intent.hasExtra(GravityBoxSettings.EXTRA_NAVBAR_KEY_COLOR)) {
-                    mKeyColor = intent.getIntExtra(
-                            GravityBoxSettings.EXTRA_NAVBAR_KEY_COLOR, mKeyDefaultColor);
+                    try {
+                    	mKeyColor = (int)Long.parseLong(intent.getStringExtra(
+                    			GravityBoxSettings.EXTRA_NAVBAR_KEY_COLOR).replaceFirst("#", ""), 16);
+                    } catch(Exception e) {                	
+	                    mKeyColor = intent.getIntExtra(
+	                            GravityBoxSettings.EXTRA_NAVBAR_KEY_COLOR, mKeyDefaultColor);
+                    }
                     setKeyColor();
                 }
                 if (intent.hasExtra(GravityBoxSettings.EXTRA_NAVBAR_KEY_GLOW_COLOR)) {
-                    mKeyGlowColor = intent.getIntExtra(
-                            GravityBoxSettings.EXTRA_NAVBAR_KEY_GLOW_COLOR, mKeyDefaultGlowColor);
+                    try {
+                    	mKeyGlowColor = (int)Long.parseLong(intent.getStringExtra(
+                    			GravityBoxSettings.EXTRA_NAVBAR_KEY_GLOW_COLOR).replaceFirst("#", ""), 16);
+                    } catch(Exception e) {                  	
+	                    mKeyGlowColor = intent.getIntExtra(
+	                            GravityBoxSettings.EXTRA_NAVBAR_KEY_GLOW_COLOR, mKeyDefaultGlowColor);
+                    }
                     setKeyColor();
                 }
                 if (intent.hasExtra(GravityBoxSettings.EXTRA_NAVBAR_BG_COLOR)) {
-                    mNavbarBgColor = intent.getIntExtra(
-                            GravityBoxSettings.EXTRA_NAVBAR_BG_COLOR, mNavbarDefaultBgColor);
+                    try {
+                    	mNavbarBgColor = (int)Long.parseLong(intent.getStringExtra(
+                    			GravityBoxSettings.EXTRA_NAVBAR_BG_COLOR).replaceFirst("#", ""), 16);
+                    } catch(Exception e) {                  	
+	                    mNavbarBgColor = intent.getIntExtra(
+	                            GravityBoxSettings.EXTRA_NAVBAR_BG_COLOR, mNavbarDefaultBgColor);
+                    }
                     setNavbarBgColor();
                 }
                 if (intent.hasExtra(GravityBoxSettings.EXTRA_NAVBAR_COLOR_ENABLE)) {

--- a/src/com/ceco/kitkat/gravitybox/ModPieControls.java
+++ b/src/com/ceco/kitkat/gravitybox/ModPieControls.java
@@ -134,24 +134,49 @@ public class ModPieControls {
                     mPieController.setMenuVisibility(mShowMenuItem | mAlwaysShowMenuItem);
                 }
                 if (intent.hasExtra(GravityBoxSettings.EXTRA_PIE_COLOR_BG)) {
-                    mPieController.setBackgroundColor(intent.getIntExtra(GravityBoxSettings.EXTRA_PIE_COLOR_BG,
-                            mGbContext.getResources().getColor(R.color.pie_background_color)));
+                    try {
+                    	mPieController.setBackgroundColor((int)Long.parseLong(intent.getStringExtra(
+                    			GravityBoxSettings.EXTRA_PIE_COLOR_BG).replaceFirst("#", ""), 16));
+                    } catch(Exception e) {                  	
+                    	mPieController.setBackgroundColor(intent.getIntExtra(GravityBoxSettings.EXTRA_PIE_COLOR_BG,
+                    			mGbContext.getResources().getColor(R.color.pie_background_color)));
+                    }
                 }
                 if (intent.hasExtra(GravityBoxSettings.EXTRA_PIE_COLOR_FG)) {
-                    mPieController.setForegroundColor(intent.getIntExtra(GravityBoxSettings.EXTRA_PIE_COLOR_FG,
-                            mGbContext.getResources().getColor(R.color.pie_foreground_color)));
+                    try {
+                    	mPieController.setForegroundColor((int)Long.parseLong(intent.getStringExtra(
+                    			GravityBoxSettings.EXTRA_PIE_COLOR_FG).replaceFirst("#", ""), 16));
+                    } catch(Exception e) {                 	
+                    	mPieController.setForegroundColor(intent.getIntExtra(GravityBoxSettings.EXTRA_PIE_COLOR_FG,
+                    			mGbContext.getResources().getColor(R.color.pie_foreground_color)));
+                    }
                 }
                 if (intent.hasExtra(GravityBoxSettings.EXTRA_PIE_COLOR_OUTLINE)) {
-                    mPieController.setOutlineColor(intent.getIntExtra(GravityBoxSettings.EXTRA_PIE_COLOR_OUTLINE,
-                            mGbContext.getResources().getColor(R.color.pie_outline_color)));
+                    try {
+                    	mPieController.setOutlineColor((int)Long.parseLong(intent.getStringExtra(
+                    			GravityBoxSettings.EXTRA_PIE_COLOR_OUTLINE).replaceFirst("#", ""), 16));
+                    } catch(Exception e) {                   	
+                    	mPieController.setOutlineColor(intent.getIntExtra(GravityBoxSettings.EXTRA_PIE_COLOR_OUTLINE,
+                    			mGbContext.getResources().getColor(R.color.pie_outline_color)));
+                    }
                 }
                 if (intent.hasExtra(GravityBoxSettings.EXTRA_PIE_COLOR_SELECTED)) {
-                    mPieController.setSelectedColor(intent.getIntExtra(GravityBoxSettings.EXTRA_PIE_COLOR_SELECTED,
-                            mGbContext.getResources().getColor(R.color.pie_selected_color)));
+                    try {
+                    	mPieController.setSelectedColor((int)Long.parseLong(intent.getStringExtra(
+                    			GravityBoxSettings.EXTRA_PIE_COLOR_SELECTED).replaceFirst("#", ""), 16));
+                    } catch(Exception e) {                 	
+                    	mPieController.setSelectedColor(intent.getIntExtra(GravityBoxSettings.EXTRA_PIE_COLOR_SELECTED,
+                    			mGbContext.getResources().getColor(R.color.pie_selected_color)));
+                    }
                 }
                 if (intent.hasExtra(GravityBoxSettings.EXTRA_PIE_COLOR_TEXT)) {
-                    mPieController.setTextColor(intent.getIntExtra(GravityBoxSettings.EXTRA_PIE_COLOR_TEXT,
-                            mGbContext.getResources().getColor(R.color.pie_text_color)));
+                    try {
+                    	mPieController.setTextColor((int)Long.parseLong(intent.getStringExtra(
+                    			GravityBoxSettings.EXTRA_PIE_COLOR_TEXT).replaceFirst("#", ""), 16));
+                    } catch(Exception e) {                 	
+                    	mPieController.setTextColor(intent.getIntExtra(GravityBoxSettings.EXTRA_PIE_COLOR_TEXT,
+                    			mGbContext.getResources().getColor(R.color.pie_text_color)));
+                    }
                 }
                 if (intent.hasExtra(GravityBoxSettings.EXTRA_PIE_BUTTON) &&
                         intent.hasExtra(GravityBoxSettings.EXTRA_PIE_LONGPRESS_ACTION)) {

--- a/src/com/ceco/kitkat/gravitybox/ModStatusbarColor.java
+++ b/src/com/ceco/kitkat/gravitybox/ModStatusbarColor.java
@@ -84,7 +84,12 @@ public class ModStatusbarColor {
             if (DEBUG) log("received broadcast: " + intent.toString());
             if (intent.getAction().equals(GravityBoxSettings.ACTION_PREF_STATUSBAR_COLOR_CHANGED)) {
                 if (intent.hasExtra(GravityBoxSettings.EXTRA_SB_BG_COLOR)) {
-                    mStatusbarBgColor = intent.getIntExtra(GravityBoxSettings.EXTRA_SB_BG_COLOR, Color.BLACK);
+                	try {
+                		mStatusbarBgColor = (int)Long.parseLong(intent.getStringExtra(
+                       			GravityBoxSettings.EXTRA_SB_BG_COLOR).replaceFirst("#", ""), 16);
+                    } catch(Exception e) {                  	
+                       	mStatusbarBgColor = intent.getIntExtra(GravityBoxSettings.EXTRA_SB_BG_COLOR, Color.BLACK);
+                    }
                     setStatusbarBgColor();
                 }
             }

--- a/src/com/ceco/kitkat/gravitybox/NotificationWallpaper.java
+++ b/src/com/ceco/kitkat/gravitybox/NotificationWallpaper.java
@@ -226,7 +226,12 @@ class NotificationWallpaper extends FrameLayout implements BroadcastSubReceiver 
                 setType(intent.getStringExtra(GravityBoxSettings.EXTRA_BG_TYPE));
             }
             if (intent.hasExtra(GravityBoxSettings.EXTRA_BG_COLOR)) {
-                setColor(intent.getIntExtra(GravityBoxSettings.EXTRA_BG_COLOR, Color.BLACK));
+                try {
+                	setColor((int)Long.parseLong(intent.getStringExtra(
+                			GravityBoxSettings.EXTRA_BG_COLOR).replaceFirst("#", ""), 16));
+                } catch(Exception e) {             	
+                	setColor(intent.getIntExtra(GravityBoxSettings.EXTRA_BG_COLOR, Color.BLACK));
+                }
             }
             if (intent.hasExtra(GravityBoxSettings.EXTRA_BG_ALPHA)) {
                 setAlpha(intent.getIntExtra(GravityBoxSettings.EXTRA_BG_ALPHA, 0));

--- a/src/com/ceco/kitkat/gravitybox/StatusBarIconManager.java
+++ b/src/com/ceco/kitkat/gravitybox/StatusBarIconManager.java
@@ -177,22 +177,42 @@ public class StatusBarIconManager implements BroadcastSubReceiver {
     public void onBroadcastReceived(Context context, Intent intent) {
         if (intent.getAction().equals(GravityBoxSettings.ACTION_PREF_STATUSBAR_COLOR_CHANGED)) {
             if (intent.hasExtra(GravityBoxSettings.EXTRA_SB_ICON_COLOR)) {
-                setIconColor(intent.getIntExtra(
-                        GravityBoxSettings.EXTRA_SB_ICON_COLOR, getDefaultIconColor()));
+                try {
+                	setIconColor((int)Long.parseLong(intent.getStringExtra(
+                			GravityBoxSettings.EXTRA_SB_ICON_COLOR).replaceFirst("#", ""), 16));
+                } catch(Exception e) {              	
+                	setIconColor(intent.getIntExtra(
+                			GravityBoxSettings.EXTRA_SB_ICON_COLOR, getDefaultIconColor()));
+                }
             } else if (intent.hasExtra(GravityBoxSettings.EXTRA_SB_ICON_STYLE)) {
                 setIconStyle(intent.getIntExtra(GravityBoxSettings.EXTRA_SB_ICON_STYLE, 0));
             } else if (intent.hasExtra(GravityBoxSettings.EXTRA_SB_ICON_COLOR_SECONDARY)) {
-                setIconColor(1, intent.getIntExtra(
-                        GravityBoxSettings.EXTRA_SB_ICON_COLOR_SECONDARY, 
-                        getDefaultIconColor()));
+                try {
+                	setIconColor(1, (int)Long.parseLong(intent.getStringExtra(
+                			GravityBoxSettings.EXTRA_SB_ICON_COLOR_SECONDARY).replaceFirst("#", ""), 16));
+                } catch(Exception e) {             	
+                	setIconColor(1, intent.getIntExtra(
+                			GravityBoxSettings.EXTRA_SB_ICON_COLOR_SECONDARY, 
+                			getDefaultIconColor()));
+                }
             } else if (intent.hasExtra(GravityBoxSettings.EXTRA_SB_DATA_ACTIVITY_COLOR)) {
-                setDataActivityColor(intent.getIntExtra(
-                        GravityBoxSettings.EXTRA_SB_DATA_ACTIVITY_COLOR, 
-                        StatusBarIconManager.DEFAULT_DATA_ACTIVITY_COLOR));
+                try {
+                	setDataActivityColor((int)Long.parseLong(intent.getStringExtra(
+                			GravityBoxSettings.EXTRA_SB_DATA_ACTIVITY_COLOR).replaceFirst("#", ""), 16));
+                } catch(Exception e) {              	
+                	setDataActivityColor(intent.getIntExtra(
+                			GravityBoxSettings.EXTRA_SB_DATA_ACTIVITY_COLOR, 
+                			StatusBarIconManager.DEFAULT_DATA_ACTIVITY_COLOR));
+                }
             } else if (intent.hasExtra(GravityBoxSettings.EXTRA_SB_DATA_ACTIVITY_COLOR_SECONDARY)) {
-                setDataActivityColor(1, intent.getIntExtra(
-                        GravityBoxSettings.EXTRA_SB_DATA_ACTIVITY_COLOR_SECONDARY, 
-                        StatusBarIconManager.DEFAULT_DATA_ACTIVITY_COLOR));
+                try {
+                	setDataActivityColor(1, (int)Long.parseLong(intent.getStringExtra(
+                			GravityBoxSettings.EXTRA_SB_DATA_ACTIVITY_COLOR_SECONDARY).replaceFirst("#", ""), 16));
+                } catch(Exception e) {             	
+                	setDataActivityColor(1, intent.getIntExtra(
+                			GravityBoxSettings.EXTRA_SB_DATA_ACTIVITY_COLOR_SECONDARY, 
+                			StatusBarIconManager.DEFAULT_DATA_ACTIVITY_COLOR));
+                }
             } else if (intent.hasExtra(GravityBoxSettings.EXTRA_SB_ICON_COLOR_ENABLE)) {
                 setColoringEnabled(intent.getBooleanExtra(
                         GravityBoxSettings.EXTRA_SB_ICON_COLOR_ENABLE, false));


### PR DESCRIPTION
In GB, all color codes are represented with 4bytes integer, which is SIGNED value.

For example, 100% opaque white color's code has 0xFFFFFFFF, which is -1 in decimal, not 4294967295 = 2^32-1.
So if user want 100% opaque white color, he has to write -1 in intent's related extra field. Of course this conversion is not impossible, but I think it's not user-friendly, and not directly usable from value taken from GB's cololr-pickers.

This little modification allows user to enter "#FF00FF00"-like-string format directly into intent's extra fields.

Adpapted extra color fields.

[NaviBar]
EXTRA_NAVBAR_BG_COLOR
EXTRA_NAVBAR_KEY_COLOR
EXTRA_NAVBAR_KEY_GLOW_COLOR
[StatusBar]
EXTRA_SB_BG_COLOR
EXTRA_SB_ICON_COLOR
EXTRA_SB_ICON_COLOR_SECONDARY
EXTRA_SB_DATA_ACTIVITY_COLOR
EXTRA_SB_DATA_ACTIVITY_COLOR_SECONDARY
[Notificafion]
EXTRA_BG_COLOR
[Pie]
EXTRA_PIE_COLOR_BG
EXTRA_PIE_COLOR_FG
EXTRA_PIE_COLOR_OUTLINE
EXTRA_PIE_COLOR_SELECTED
EXTRA_PIE_COLOR_TEXT

For example if we want to have 100% opaque green naviBar background,
send intent filled with,
action = "gravitybox.intent.action.ACTION_NAVBAR_CHANGED"
extra = "navbarBgColor:#ff00ff00"
