### PR TITLE
forgot the master switch title at navbar

### DIFF
--- a/res/xml/gravitybox.xml
+++ b/res/xml/gravitybox.xml
@@ -746,7 +746,7 @@
 
             <SwitchPreference 
                 android:key="pref_navbar_override"
-                android:title=""
+                android:title="@string/pref_masterswitch_title"
                 android:summary="@string/pref_navbar_override_summary"
                 android:defaultValue="false" />
 


### PR DESCRIPTION
there are no empty titles in the file anymore, so I'm pretty sure there are no missing titles now
