### PR TITLE
QS: add more long press handlers 

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -162,6 +162,7 @@
         <item>@string/qs_tile_gps</item>
         <item>@string/qs_tile_autorotation</item>
         <item>@string/qs_tile_settings</item>
+        <item>@string/qs_tile_brightness</item>
     </string-array>
 
     <string-array name="qs_tile_override_values" translatable="false">
@@ -172,6 +173,7 @@
         <item>gps_textview</item>
         <item>auto_rotate_textview</item>
         <item>settings</item>
+        <item>brightness_textview</item>
     </string-array>
 
     <string-array name="lockscreen_bg_entries" translatable="false">

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -161,6 +161,7 @@
         <item>@string/qs_tile_airplane_mode</item>
         <item>@string/qs_tile_gps</item>
         <item>@string/qs_tile_autorotation</item>
+        <item>@string/qs_tile_settings</item>
     </string-array>
 
     <string-array name="qs_tile_override_values" translatable="false">
@@ -170,6 +171,7 @@
         <item>airplane_mode_textview</item>
         <item>gps_textview</item>
         <item>auto_rotate_textview</item>
+        <item>settings</item>
     </string-array>
 
     <string-array name="lockscreen_bg_entries" translatable="false">

--- a/src/com/ceco/kitkat/gravitybox/ModQuickSettings.java
+++ b/src/com/ceco/kitkat/gravitybox/ModQuickSettings.java
@@ -1332,6 +1332,15 @@ public class ModQuickSettings {
                                 }
                             }
                         });
+                        tile.setOnLongClickListener(new View.OnLongClickListener() {
+                            @Override
+                            public boolean onLongClick(View v) {
+                                XposedHelpers.callMethod(mQuickSettings, "startSettingsActivity", 
+                                        android.provider.Settings.ACTION_AIRPLANE_MODE_SETTINGS);
+                                tile.setPressed(false);
+                                return true;
+                            }
+                        });
                     }
                 }
             });

--- a/src/com/ceco/kitkat/gravitybox/ModQuickSettings.java
+++ b/src/com/ceco/kitkat/gravitybox/ModQuickSettings.java
@@ -1165,7 +1165,26 @@ public class ModQuickSettings {
                     CLASS_QS_TILEVIEW, CLASS_QS_MODEL_RCB, new XC_MethodHook() {
                 @Override
                 protected void afterHookedMethod(final MethodHookParam param) throws Throwable {
-                    ((View)param.args[0]).setTag(mAospTileTags.get("settings"));
+                    final View tile = (View) param.args[0];
+                    tile.setTag(mAospTileTags.get("settings"));
+                    if (mOverrideTileKeys.contains("settings")) {
+	                    tile.setOnLongClickListener(new View.OnLongClickListener() {
+	                        @Override
+	                        public boolean onLongClick(View v) {
+	                            Intent i = new Intent();
+	                            i.setClassName(GravityBox.PACKAGE_NAME, GravityBoxSettings.class.getName());
+	                            try {
+	                                XposedHelpers.callMethod(mQuickSettings, "startSettingsActivity", i);
+	                            } catch (Throwable t) {
+	                                // fallback in case of troubles
+	                                i.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+	                                mContext.startActivity(i);
+	                            }
+	                            tile.setPressed(false);
+	                            return true;
+	                        }
+	                    });
+                    }
                 }
             });
         } catch (Throwable t) {

--- a/src/com/ceco/kitkat/gravitybox/ModQuickSettings.java
+++ b/src/com/ceco/kitkat/gravitybox/ModQuickSettings.java
@@ -1293,6 +1293,15 @@ public class ModQuickSettings {
                                 }
                             }
                         });
+                        tile.setOnLongClickListener(new View.OnLongClickListener() {
+                            @Override
+                            public boolean onLongClick(View v) {
+                                XposedHelpers.callMethod(mQuickSettings, "startSettingsActivity", 
+                                        android.provider.Settings.ACTION_ACCESSIBILITY_SETTINGS);
+                                tile.setPressed(false);
+                                return true;
+                            }
+                        });
                     }
                 }
             });

--- a/src/com/ceco/kitkat/gravitybox/ModQuickSettings.java
+++ b/src/com/ceco/kitkat/gravitybox/ModQuickSettings.java
@@ -1153,7 +1153,19 @@ public class ModQuickSettings {
                     CLASS_QS_TILEVIEW, CLASS_QS_MODEL_RCB, new XC_MethodHook() {
                 @Override
                 protected void afterHookedMethod(final MethodHookParam param) throws Throwable {
-                    ((View)param.args[0]).setTag(mAospTileTags.get("brightness_textview"));
+                    final View tile = (View) param.args[0];
+                    tile.setTag(mAospTileTags.get("brightness_textview"));
+                    if (mOverrideTileKeys.contains("brightness_textview")) {
+                        tile.setOnLongClickListener(new View.OnLongClickListener() {
+                            @Override
+                            public boolean onLongClick(View v) {
+                                XposedHelpers.callMethod(mQuickSettings, "startSettingsActivity", 
+                                        android.provider.Settings.ACTION_DISPLAY_SETTINGS);
+                                 tile.setPressed(false);
+                                return true;
+                            }
+                        });
+                    }
                 }
             });
         } catch (Throwable t) {


### PR DESCRIPTION
I've added long press handlers for few quick settings tiles
- airplane mode: open airplane mode settings 
- auto rotate: open accessibility settings
- brightness: open display settings
- settings: open GB settings
