### PR TITLE
Restructured status bar clock settings

### DIFF
--- a/res/xml/gravitybox.xml
+++ b/res/xml/gravitybox.xml
@@ -16,16 +16,16 @@
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
 
-    <PreferenceScreen
+	<PreferenceScreen
         android:key="pref_cat_lockscreen"
         android:title="@string/pref_cat_lockscreen_title"
         android:summary="@string/pref_cat_lockscreen_summary">
 
-        <PreferenceCategory 
+		<PreferenceCategory 
             android:key="pref_cat_lockscreen_background"
             android:title="@string/pref_cat_lockscreen_background_title">
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_lockscreen_background"
                 android:title="@string/pref_lockscreen_background_title"
                 android:entries="@array/lockscreen_bg_entries"
@@ -33,26 +33,26 @@
                 android:defaultValue="default"
                 android:order="1" />
 
-            <net.margaritov.preference.colorpicker.ColorPickerPreference 
+			<net.margaritov.preference.colorpicker.ColorPickerPreference 
                 android:key="pref_lockscreen_bg_color"
                 android:title="@string/pref_lockscreen_bg_color_title"
                 android:summary="@string/pref_lockscreen_bg_color_summary"
                 android:defaultValue="@integer/COLOR_BLACK"
                 android:order="2" />
 
-            <Preference
+			<Preference
                 android:key="pref_lockscreen_bg_image"
                 android:title="@string/pref_lockscreen_bg_image_title"
                 android:summary="@string/pref_lockscreen_bg_image_summary"
                 android:order="3" />
 
-            <CheckBoxPreference
+			<CheckBoxPreference
                 android:key="pref_lockscreen_bg_blur_effect"
                 android:title="@string/pref_lockscreen_bg_blur_effect_title"
                 android:defaultValue="false"
                 android:order="4" />
 
-            <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+			<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                 android:key="pref_lockscreen_bg_blur_intensity"
                 android:title="@string/pref_lockscreen_bg_blur_intensity_title"
                 minimum="1"
@@ -62,7 +62,7 @@
                 android:order="5"
                 android:dependency="pref_lockscreen_bg_blur_effect" />
 
-            <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+			<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                 android:key="pref_lockscreen_bg_opacity"
                 android:title="@string/pref_lockscreen_bg_opacity_title"
                 android:summary="@string/pref_lockscreen_bg_opacity_summary"
@@ -74,84 +74,84 @@
                 android:defaultValue="50"
                 android:order="6" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-        <PreferenceCategory 
+		<PreferenceCategory 
             android:key="pref_cat_lockscreen_sliding_challenge"
             android:title="@string/pref_cat_lockscreen_sliding_challenge_title">
 
-            <PreferenceScreen 
+			<PreferenceScreen 
                 android:key="pref_cat_lockscreen_ring_settings"
                 android:title="@string/pref_cat_lockscreen_ring_settings_title">
 
-                <SwitchPreference 
+				<SwitchPreference 
                     android:key="pref_lockscreen_ring_targets_enable"
                     android:title="@string/pref_masterswitch_title"
                     android:summary="@string/pref_lockscreen_ring_targets_enable_summary"
                     android:defaultValue="false" />
 
-                <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+				<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                     android:key="pref_lockscreen_ring_targets_app0"
                     android:title="@string/pref_lockscreen_ring_targets_app_title"
                     android:summary="@string/app_picker_none" />
 
-                <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+				<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                     android:key="pref_lockscreen_ring_targets_app1"
                     android:title="@string/pref_lockscreen_ring_targets_app_title"
                     android:summary="@string/app_picker_none" />
 
-                <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+				<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                     android:key="pref_lockscreen_ring_targets_app2"
                     android:title="@string/pref_lockscreen_ring_targets_app_title"
                     android:summary="@string/app_picker_none" />
 
-                <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+				<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                     android:key="pref_lockscreen_ring_targets_app3"
                     android:title="@string/pref_lockscreen_ring_targets_app_title"
                     android:summary="@string/app_picker_none" />
 
-                <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+				<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                     android:key="pref_lockscreen_ring_targets_app4"
                     android:title="@string/pref_lockscreen_ring_targets_app_title"
                     android:summary="@string/app_picker_none" />
 
-                <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+				<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                     android:key="pref_lockscreen_ring_targets_app5"
                     android:title="@string/pref_lockscreen_ring_targets_app_title"
                     android:summary="@string/app_picker_none" />
 
-                <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+				<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                     android:key="pref_lockscreen_ring_targets_app6"
                     android:title="@string/pref_lockscreen_ring_targets_app_title"
                     android:summary="@string/app_picker_none" />
 
-            </PreferenceScreen>
+			</PreferenceScreen>
 
-            <CheckBoxPreference
+			<CheckBoxPreference
                 android:key="pref_lockscreen_battery_arc"
                 android:title="@string/pref_lockscreen_battery_arc_title"
                 android:summary="@string/pref_lockscreen_battery_arc_summary"
                 android:defaultValue="false" />
 
-            <CheckBoxPreference
+			<CheckBoxPreference
                 android:key="pref_lockscreen_ring_torch"
                 android:title="@string/pref_lockscreen_ring_torch_title"
                 android:summary="@string/pref_lockscreen_ring_torch_summary"
                 android:defaultValue="false" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_lockscreen_slide_before_unlock"
                 android:title="@string/pref_lockscreen_slide_before_unlock_title"
                 android:summary="@string/pref_lockscreen_slide_before_unlock_summary"
                 android:defaultValue="false" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_lockscreen_ring_dt2s"
                 android:title="@string/pref_lockscreen_ring_dt2s_title"
                 android:summary="@string/pref_lockscreen_ring_dt2s_summary"
                 android:defaultValue="false" />
 
-            <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+			<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                 android:key="pref_lockscreen_ring_targets_vertical_offset"
                 android:title="@string/pref_lockscreen_ring_vertical_offset_title"
                 minimum="-50"
@@ -161,7 +161,7 @@
                 monitorBoxUnit="px" 
                 android:defaultValue="0" />
 
-            <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+			<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                 android:key="pref_lockscreen_ring_targets_horizontal_offset"
                 android:title="@string/pref_lockscreen_ring_horizontal_offset_title"
                 minimum="-30"
@@ -171,92 +171,92 @@
                 monitorBoxUnit="px" 
                 android:defaultValue="0" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-        <PreferenceCategory 
+		<PreferenceCategory 
             android:key="pref_cat_lockscreen_widgets"
             android:title="@string/pref_cat_lockscreen_widgets_title">
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_lockscreen_maximize_widgets"
                 android:title="@string/pref_lockscreen_maximize_widgets_title"
                 android:summary="@string/pref_lockscreen_maximize_widgets_summary"
                 android:defaultValue="false" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_lockscreen_widget_limit_disable"
                 android:title="@string/pref_lockscreen_widget_limit_disable_title"
                 android:summary="@string/pref_lockscreen_widget_limit_disable_summary"
                 android:defaultValue="false" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-        <PreferenceCategory 
+		<PreferenceCategory 
             android:key="pref_cat_lockscreen_statusbar"
             android:title="@string/pref_cat_lockscreen_statusbar_title">
 
-            <ListPreference 
+			<ListPreference 
                 android:key="pref_statusbar_lock_policy"
                 android:title="@string/pref_statusbar_lock_policy_title"
                 android:entries="@array/statusbar_lock_policy_entries"
                 android:entryValues="@array/statusbar_lock_policy_values"
                 android:defaultValue="0" />
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_lockscreen_statusbar_clock"
                 android:title="@string/pref_lockscreen_sb_clock_title"
                 android:entries="@array/lockscreen_sb_clock_entries"
                 android:entryValues="@array/lockscreen_sb_clock_values"
                 android:defaultValue="0" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-        <PreferenceCategory
+		<PreferenceCategory
             android:key="pref_cat_lockscreen_other"
             android:title="@string/pref_cat_lockscreen_other_title">
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_lockscreen_rotation"
                 android:title="@string/pref_lockscreen_rotation_title"
                 android:defaultValue="false" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_lockscreen_menu_key"
                 android:title="@string/pref_lockscreen_menu_key_title"
                 android:summary="@string/pref_lockscreen_menu_key_summary"
                 android:defaultValue="false" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_lockscreen_quick_unlock"
                 android:title="@string/pref_lockscreen_quick_unlock_title"
                 android:summary="@string/pref_lockscreen_quick_unlock_summary"
                 android:defaultValue="false" />
 
-            <EditTextPreference 
+			<EditTextPreference 
                 android:key="pref_lockscreen_carrier_text"
                 android:title="@string/pref_lockscreen_carrier_text_title"
                 android:defaultValue="" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-    </PreferenceScreen>
+	</PreferenceScreen>
 
-    <PreferenceScreen 
+	<PreferenceScreen 
         android:key="pref_cat_statusbar"
         android:title="@string/pref_cat_statusbar_title"
         android:summary="@string/pref_cat_statusbar_summary">
 
-        <PreferenceScreen
+		<PreferenceScreen
             android:key="pref_cat_statusbar_qs"
             android:title="@string/pref_cat_statusbar_qs_title">
 
-            <SwitchPreference
+			<SwitchPreference
                 android:key="pref_qs_management_enable"
                 android:title="@string/pref_masterswitch_title"
                 android:summary="@string/pref_qs_management_enable_summary"
                 android:defaultValue="true" />
 
-            <MultiSelectListPreference 
+			<MultiSelectListPreference 
                 android:key="pref_quick_settings2"
                 android:title="@string/quick_settings_title"
                 android:summary="@string/quick_settings_summary"
@@ -265,13 +265,13 @@
                 android:defaultValue="@array/qs_tile_aosp_values_kk"
                 android:dependency="pref_qs_management_enable" />
 
-            <PreferenceScreen 
+			<PreferenceScreen 
                 android:key="pref_cat_qs_tile_settings"
                 android:title="@string/pref_cat_qs_tile_settings_title"
                 android:summary="@string/pref_cat_qs_tile_settings_summary"
                 android:dependency="pref_qs_management_enable">
 
-                <MultiSelectListPreference 
+				<MultiSelectListPreference 
                     android:key="pref_qs_tile_behaviour_override"
                     android:title="@string/pref_qs_tile_behaviour_override_title"
                     android:summary="@string/pref_qs_tile_behaviour_override_summary"
@@ -279,133 +279,133 @@
                     android:entryValues="@array/qs_tile_override_values"
                     android:defaultValue="@array/empty_array" />
 
-                <PreferenceScreen
+				<PreferenceScreen
                     android:key="pref_cat_qs_alarm_tile_settings"
                     android:title="@string/pref_cat_qs_alarm_tile_settings_title">
 
-                    <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+					<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                         android:key="pref_qs_alarm_singletap_app"
                         android:title="@string/pref_qs_alarm_singletap_app_title"
                         android:summary="@string/alarm_singletap_app_default"
                         iconPickerEnabled="false" />
 
-                    <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+					<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                         android:key="pref_qs_alarm_longpress_app"
                         android:title="@string/pref_qs_alarm_longpress_app_title"
                         android:summary="@string/app_picker_none"
                         iconPickerEnabled="false" />
 
-                </PreferenceScreen>
+				</PreferenceScreen>
 
-                <PreferenceScreen
+				<PreferenceScreen
                     android:key="pref_cat_quick_app_tile"
                     android:title="@string/pref_cat_quickapp_tile_title">
 
-                    <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+					<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                         android:key="pref_quickapp_default"
                         android:title="@string/pref_quickapp_default_title"
                         android:summary="@string/app_picker_none" />
 
-                    <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+					<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                         android:key="pref_quickapp_slot1"
                         android:title="@string/pref_quickapp_slot1_title"
                         android:summary="@string/app_picker_none" />
 
-                    <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+					<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                         android:key="pref_quickapp_slot2"
                         android:title="@string/pref_quickapp_slot2_title"
                         android:summary="@string/app_picker_none" />
 
-                    <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+					<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                         android:key="pref_quickapp_slot3"
                         android:title="@string/pref_quickapp_slot3_title"
                         android:summary="@string/app_picker_none" />
 
-                    <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+					<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                         android:key="pref_quickapp_slot4"
                         android:title="@string/pref_quickapp_slot4_title"
                         android:summary="@string/app_picker_none" />
 
-                </PreferenceScreen>
+				</PreferenceScreen>
 
-                <PreferenceScreen
+				<PreferenceScreen
                     android:key="pref_cat_quick_app_tile_2"
                     android:title="@string/pref_cat_quickapp_tile_2_title">
 
-                    <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+					<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                         android:key="pref_quickapp_default_2"
                         android:title="@string/pref_quickapp_default_title"
                         android:summary="@string/app_picker_none" />
 
-                    <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+					<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                         android:key="pref_quickapp_slot1_2"
                         android:title="@string/pref_quickapp_slot1_title"
                         android:summary="@string/app_picker_none" />
 
-                    <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+					<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                         android:key="pref_quickapp_slot2_2"
                         android:title="@string/pref_quickapp_slot2_title"
                         android:summary="@string/app_picker_none" />
 
-                    <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+					<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                         android:key="pref_quickapp_slot3_2"
                         android:title="@string/pref_quickapp_slot3_title"
                         android:summary="@string/app_picker_none" />
 
-                    <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+					<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                         android:key="pref_quickapp_slot4_2"
                         android:title="@string/pref_quickapp_slot4_title"
                         android:summary="@string/app_picker_none" />
 
-                </PreferenceScreen>
+				</PreferenceScreen>
 
-                <PreferenceScreen 
+				<PreferenceScreen 
                     android:key="pref_cat_qs_nm_tile_settings"
                     android:title="@string/pref_cat_qs_nm_tile_settings_title">
 
-                    <ListPreference
+					<ListPreference
                         android:key="pref_network_mode_tile_mode" 
                         android:title="@string/pref_network_mode_tile_mode_title"
                         android:entries="@array/network_mode_tile_mode_entries"
                         android:entryValues="@array/network_mode_tile_mode_values"
                         android:defaultValue="0" />
 
-                    <CheckBoxPreference 
+					<CheckBoxPreference 
                         android:key="pref_network_mode_tile_lte"
                         android:title="@string/pref_network_mode_tile_lte_title"
                         android:defaultValue="false" />
 
-                    <CheckBoxPreference 
+					<CheckBoxPreference 
                         android:key="pref_network_mode_tile_cdma"
                         android:title="@string/pref_network_mode_tile_cdma_title"
                         android:defaultValue="false" />
 
-                </PreferenceScreen>
+				</PreferenceScreen>
 
-                <MultiSelectListPreference 
+				<MultiSelectListPreference 
                     android:key="pref_qs_ringer_mode"
                     android:title="@string/pref_qs_ringer_mode_title"
                     android:entries="@array/ringer_mode_entries"
                     android:entryValues="@array/ringer_mode_values"
                     android:defaultValue="@array/ringer_mode_values" />
 
-                <MultiSelectListPreference 
+				<MultiSelectListPreference 
                     android:key="pref_qs_stay_awake"
                     android:title="@string/pref_qs_stay_awake_title"
                     android:entries="@array/stay_awake_entries"
                     android:entryValues="@array/stay_awake_values"
                     android:defaultValue="@array/stay_awake_values" />
 
-            </PreferenceScreen>
+			</PreferenceScreen>
 
-            <Preference
+			<Preference
                 android:key="pref_qs_tile_order"
                 android:title="@string/pref_qs_tile_order_title"
                 android:summary="@string/pref_qs_tile_order_summary"
                 android:persistent="false"
                 android:dependency="pref_qs_management_enable" />
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_qs_tiles_per_row" 
                 android:title="@string/pref_qs_tiles_per_row_title"
                 android:summary="@string/pref_qs_tiles_per_row_summary" 
@@ -414,7 +414,7 @@
                 android:defaultValue="3"
                 android:dependency="pref_qs_management_enable" />
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_qs_tile_label_style" 
                 android:title="@string/pref_qs_tile_label_style_title" 
                 android:entries="@array/tile_label_style_entries"
@@ -422,21 +422,21 @@
                 android:defaultValue="ALLCAPS"
                 android:dependency="pref_qs_management_enable" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_qs_hide_on_change"
                 android:title="@string/pref_qs_hide_on_change_title"
                 android:summary="@string/pref_qs_hide_on_change_summary"
                 android:defaultValue="false"
                 android:dependency="pref_qs_management_enable" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_qs_tile_span_disable"
                 android:title="@string/pref_qs_tile_span_disable_title"
                 android:summary="@string/pref_qs_tile_span_disable_summary"
                 android:defaultValue="false"
                 android:dependency="pref_qs_management_enable" />
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_qs_network_mode_sim_slot" 
                 android:title="@string/pref_qs_network_mode_sim_slot_title"
                 android:entries="@array/network_mode_sim_slot_entries"
@@ -444,7 +444,7 @@
                 android:defaultValue="0"
                 android:dependency="pref_qs_management_enable" />
 
-            <ListPreference 
+			<ListPreference 
                 android:key="pref_auto_switch_qs2"
                 android:title="@string/pref_auto_switch_qs_title"
                 android:summary="@string/pref_auto_switch_qs_summary"
@@ -452,8 +452,8 @@
                 android:entryValues="@array/qs_auto_switch_values"
                 android:defaultValue="0"
                 android:dependency="pref_qs_management_enable" />
-    
-            <ListPreference
+
+			<ListPreference
                 android:key="pref_quick_pulldown" 
                 android:title="@string/pref_quick_pulldown_title"
                 android:summary="@string/pref_quick_pulldown_summary"
@@ -462,7 +462,7 @@
                 android:defaultValue="0"
                 android:dependency="pref_qs_management_enable" />
 
-            <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+			<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                 android:key="pref_quick_pulldown_size"
                 android:title="@string/pref_quick_pulldown_size_title"
                 minimum="10"
@@ -472,64 +472,64 @@
                 monitorBoxUnit="%" 
                 android:defaultValue="15" />
 
-        </PreferenceScreen>
+		</PreferenceScreen>
 
-        <PreferenceScreen
+		<PreferenceScreen
             android:key="pref_cat_signal_cluster"
             android:title="@string/pref_cat_signal_cluster_title">
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_signal_cluster_connection_state"
                 android:title="@string/pref_signal_cluster_connection_state_title"
                 android:summary="@string/pref_signal_cluster_connection_state_summary"
                 android:defaultValue="false" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_signal_cluster_data_activity"
                 android:title="@string/pref_signal_cluster_data_activity_title"
                 android:summary="@string/pref_signal_cluster_data_activity_summary"
                 android:defaultValue="false" />
 
-            <net.margaritov.preference.colorpicker.ColorPickerPreference 
+			<net.margaritov.preference.colorpicker.ColorPickerPreference 
                 android:key="pref_signal_cluster_data_activity_color"
                 android:title="@string/pref_statusbar_data_activity_color_title" 
                 android:summary="@string/pref_statusbar_data_activity_color_summary"
                 android:defaultValue="@integer/signal_cluster_data_activity_icon_color"
                 android:dependency="pref_signal_cluster_data_activity" />
 
-            <!-- this pref is hidden, but we keep it for potential future use -->
-            <net.margaritov.preference.colorpicker.ColorPickerPreference 
+			<!-- this pref is hidden, but we keep it for potential future use -->
+			<net.margaritov.preference.colorpicker.ColorPickerPreference 
                 android:key="pref_signal_cluster_data_activity_color_secondary"
                 android:title="@string/pref_statusbar_data_activity_color_secondary_title" 
                 android:summary="@string/pref_statusbar_data_activity_color_secondary_summary"
                 android:defaultValue="@integer/signal_cluster_data_activity_icon_color"
                 android:dependency="pref_signal_cluster_data_activity" />
 
-        </PreferenceScreen>
+		</PreferenceScreen>
 
-        <PreferenceScreen 
+		<PreferenceScreen 
             android:key="pref_cat_statusbar_colors"
             android:title="@string/pref_cat_statusbar_colors_title">
 
-            <SwitchPreference 
+			<SwitchPreference 
                 android:key="pref_statusbar_icon_color_enable"
                 android:summary="@string/pref_statusbar_icon_color_enable_title"
                 android:defaultValue="false" />
 
-            <net.margaritov.preference.colorpicker.ColorPickerPreference 
+			<net.margaritov.preference.colorpicker.ColorPickerPreference 
                 android:key="pref_statusbar_bgcolor2"
                 android:title="@string/statusbar_bgcolor_title" 
                 android:summary="@string/statusbar_bgcolor_summary"
                 android:defaultValue="@integer/COLOR_BLACK"
                 android:dependency="pref_statusbar_icon_color_enable" />
 
-            <net.margaritov.preference.colorpicker.ColorPickerPreference 
+			<net.margaritov.preference.colorpicker.ColorPickerPreference 
                 android:key="pref_statusbar_icon_color"
                 android:title="@string/pref_statusbar_icon_color_title" 
                 android:summary="@string/pref_statusbar_icon_color_summary"
                 android:defaultValue="@integer/COLOR_HOLO_BLUE_LIGHT" />
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_status_icon_style" 
                 android:title="@string/pref_status_icon_style_title"
                 android:summary="@string/pref_status_icon_style_summary"
@@ -538,26 +538,26 @@
                 android:dependency="pref_statusbar_icon_color_enable"
                 android:defaultValue="1" />
 
-            <net.margaritov.preference.colorpicker.ColorPickerPreference 
+			<net.margaritov.preference.colorpicker.ColorPickerPreference 
                 android:key="pref_statusbar_icon_color_secondary"
                 android:title="@string/pref_statusbar_icon_color_secondary_title" 
                 android:summary="@string/pref_statusbar_icon_color_secondary_summary"
                 android:defaultValue="@integer/COLOR_HOLO_BLUE_LIGHT" />
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_statusbar_signal_color_mode" 
                 android:title="@string/pref_statusbar_signal_color_mode_title"
                 android:entries="@array/signal_color_mode_entries"
                 android:entryValues="@array/signal_color_mode_values"
                 android:defaultValue="1" />
 
-        </PreferenceScreen>
+		</PreferenceScreen>
 
-        <PreferenceScreen
+		<PreferenceScreen
             android:key="pref_cat_notification_drawer_style"
             android:title="@string/pref_cat_notification_drawer_style_title" >
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_notif_background"
                 android:title="@string/pref_notif_background_title"
                 android:entries="@array/notif_background_entries"
@@ -565,23 +565,23 @@
                 android:defaultValue="default"
                 android:order="1" />
 
-            <net.margaritov.preference.colorpicker.ColorPickerPreference 
+			<net.margaritov.preference.colorpicker.ColorPickerPreference 
                 android:key="pref_notif_color"
                 android:title="@string/pref_notif_color_title"
                 android:defaultValue="@integer/COLOR_BLACK"
                 android:order="2" />
 
-            <Preference
+			<Preference
                 android:key="pref_notif_image_portrait"
                 android:title="@string/pref_notif_image_portrait_title"
                 android:order="3" />
 
-            <Preference
+			<Preference
                 android:key="pref_notif_image_landscape"
                 android:title="@string/pref_notif_image_landscape_title"
                 android:order="4" />
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_notif_color_mode"
                 android:title="@string/pref_notif_color_mode_title"
                 android:entries="@array/notif_color_mode_entries"
@@ -589,7 +589,7 @@
                 android:defaultValue="overlay"
                 android:order="5" />
 
-            <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+			<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                 android:key="pref_notif_background_alpha"
                 android:title="@string/pref_notif_background_alpha_title"
                 minimum="0"
@@ -600,38 +600,38 @@
                 android:order="6"
                 android:defaultValue="0" />
 
-            <EditTextPreference 
+			<EditTextPreference 
                 android:key="pref_notif_carrier_text"
                 android:title="@string/pref_lockscreen_carrier_text_title"
                 android:order="7"
                 android:defaultValue="" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_notif_expand_all"
                 android:title="@string/pref_notif_expand_all_title"
                 android:summary="@string/pref_notif_expand_all_summary"
                 android:order="8"
                 android:defaultValue="false" />
 
-        </PreferenceScreen>
+		</PreferenceScreen>
 
-        <PreferenceScreen
+		<PreferenceScreen
             android:key="pref_cat_battery_settings"
             android:title="@string/pref_cat_battery_settings_title">
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_battery_style" 
                 android:title="@string/battery_style_title" 
                 android:entries="@array/battery_style_entries"
                 android:entryValues="@array/battery_style_values"
                 android:defaultValue="1" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_battery_percent_text"
                 android:title="@string/battery_percent_text_title"
                 android:defaultValue="false" />
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_battery_percent_text_size"
                 android:title="@string/battery_percent_text_size_title" 
                 android:entries="@array/battery_percent_text_size_entries"
@@ -639,7 +639,7 @@
                 android:dependency="pref_battery_percent_text"
                 android:defaultValue="16" />
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_battery_percent_text_style"
                 android:title="@string/battery_percent_text_style_title" 
                 android:entries="@array/battery_percent_text_style_entries"
@@ -647,7 +647,7 @@
                 android:dependency="pref_battery_percent_text"
                 android:defaultValue="%" />
 
-            <ListPreference 
+			<ListPreference 
                 android:key="battery_percent_text_charging"
                 android:title="@string/battery_percent_text_charging_title"
                 android:dependency="pref_battery_percent_text"
@@ -655,37 +655,44 @@
                 android:entryValues="@array/bpt_charging_values"
                 android:defaultValue="0" />
 
-        </PreferenceScreen>
+		</PreferenceScreen>
 
-        <PreferenceScreen
+		<PreferenceScreen
             android:key="pref_cat_clock_settings"
             android:title="@string/pref_cat_clock_settings_title">
-
-            <PreferenceCategory 
+			
+			<PreferenceCategory 
                 android:key="pref_cat_statusbar_clock"
                 android:title="@string/pref_cat_statusbar_clock_title">
 
-                <SwitchPreference 
+				<SwitchPreference 
                     android:key="pref_sb_clock_masterswitch"
                     android:title="@string/pref_masterswitch_title"
                     android:summary="@string/pref_sb_clock_masterswitch_summary"
                     android:defaultValue="true" />
+					
+				<CheckBoxPreference 
+                    android:key="pref_clock_hide"
+                    android:title="@string/pref_clock_hide_title"
+                    android:defaultValue="false"
+                    android:dependency="pref_sb_clock_masterswitch"
+					android:disableDependentsState="true"/>
 
-                <CheckBoxPreference 
+				<CheckBoxPreference 
                     android:key="pref_statusbar_center_clock"
                     android:title="@string/pref_statusbar_center_clock_title"
                     android:defaultValue="false"
-                    android:dependency="pref_sb_clock_masterswitch" />
+                    android:dependency="pref_clock_hide" />
 
-                <ListPreference 
+				<ListPreference 
                     android:key="pref_statusbar_clock_dow2"
                     android:title="@string/pref_statusbar_clock_dow_title"
                     android:entries="@array/clock_dow_entries"
                     android:entryValues="@array/clock_dow_values"
                     android:defaultValue="0"
-                    android:dependency="pref_sb_clock_masterswitch" />
+                    android:dependency="pref_clock_hide" />
 
-                <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+				<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                     android:key="pref_sb_clock_dow_size"
                     android:title="@string/pref_sb_clock_dow_size_title"
                     minimum="40"
@@ -694,15 +701,16 @@
                     monitorBoxEnabled="true"
                     monitorBoxUnit="%"
                     android:defaultValue="70"
-                    android:dependency="pref_sb_clock_masterswitch" />
+                    android:dependency="pref_clock_hide" />
 
-                <CheckBoxPreference 
+				<CheckBoxPreference 
                     android:key="pref_clock_ampm_hide"
                     android:title="@string/pref_clock_ampm_hide_title"
                     android:defaultValue="false"
-                    android:dependency="pref_sb_clock_masterswitch" />
+                    android:dependency="pref_clock_hide"
+					android:disableDependentsState="true"/>
 
-                <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+				<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                     android:key="pref_sb_clock_ampm_size"
                     android:title="@string/pref_sb_clock_ampm_size_title"
                     minimum="40"
@@ -711,228 +719,224 @@
                     monitorBoxEnabled="true"
                     monitorBoxUnit="%"
                     android:defaultValue="70"
-                    android:dependency="pref_sb_clock_masterswitch" />
+                    android:dependency="pref_clock_ampm_hide" />
 
-                <CheckBoxPreference 
-                    android:key="pref_clock_hide"
-                    android:title="@string/pref_clock_hide_title"
-                    android:defaultValue="false"
-                    android:dependency="pref_sb_clock_masterswitch" />
 
-                <CheckBoxPreference 
+				<CheckBoxPreference 
                     android:key="pref_alarm_icon_hide"
                     android:title="@string/pref_alarm_icon_hide_title"
-                    android:defaultValue="false" />
+                    android:defaultValue="false"
+					android:dependency="pref_sb_clock_masterswitch"	/>
 
-            </PreferenceCategory>
+			</PreferenceCategory>
 
-            <PreferenceCategory 
+			<PreferenceCategory 
                 android:key="pref_cat_notif_panel_clock"
                 android:title="@string/pref_cat_notif_panel_clock_title">
 
-                <com.ceco.kitkat.gravitybox.preference.AppPickerPreference 
+				<com.ceco.kitkat.gravitybox.preference.AppPickerPreference 
                     android:key="pref_clock_link_app"
                     android:title="@string/pref_clock_link_title"
                     android:summary="@string/pref_clock_link_summary"
                     iconPickerEnabled="false" />
 
-                <com.ceco.kitkat.gravitybox.preference.AppPickerPreference 
+				<com.ceco.kitkat.gravitybox.preference.AppPickerPreference 
                     android:key="pref_clock_longpress_link"
                     android:title="@string/pref_clock_longpress_link_title"
                     android:summary="@string/app_picker_none"
                     iconPickerEnabled="false" />
 
-            </PreferenceCategory>
+			</PreferenceCategory>
 
-        </PreferenceScreen>
+		</PreferenceScreen>
 
-        <PreferenceScreen 
+		<PreferenceScreen 
             android:key="pref_cat_data_traffic"
             android:title="@string/pref_cat_data_traffic_title">
 
-            <ListPreference 
+			<ListPreference 
                 android:key="pref_data_traffic_mode"
                 android:title="@string/pref_data_traffic_mode_title"
                 android:entries="@array/data_traffic_mode_entries"
                 android:entryValues="@array/data_traffic_mode_values"
                 android:defaultValue="OFF" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_data_traffic_active_dl_only"
                 android:title="@string/pref_data_traffic_active_dl_only_title"
                 android:summary="@string/pref_data_traffic_active_dl_only_summary"
                 android:defaultValue="false" />
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_data_traffic_position"
                 android:title="@string/pref_data_traffic_position_title" 
                 android:entries="@array/data_traffic_position_entries"
                 android:entryValues="@array/data_traffic_position_values"
                 android:defaultValue="0" />
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_data_traffic_size"
                 android:title="@string/pref_data_traffic_size_title" 
                 android:entries="@array/data_traffic_size_entries"
                 android:entryValues="@array/data_traffic_size_values"
                 android:defaultValue="14" />
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_data_traffic_inactivity_mode"
                 android:title="@string/pref_data_traffic_inactivity_mode_title" 
                 android:entries="@array/data_traffic_inactivity_mode_entries"
                 android:entryValues="@array/data_traffic_inactivity_mode_values"
                 android:defaultValue="0" />
 
-            <ListPreference 
+			<ListPreference 
                 android:key="pref_data_traffic_omni_mode"
                 android:title="@string/pref_data_traffic_omni_mode_title"
                 android:entries="@array/data_traffic_omni_mode_entries"
                 android:entryValues="@array/data_traffic_omni_mode_values"
                 android:defaultValue="IN_OUT" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_data_traffic_omni_show_icon"
                 android:title="@string/pref_data_traffic_omni_show_icon_title"
                 android:defaultValue="true" />
 
-        </PreferenceScreen>
+		</PreferenceScreen>
 
-        <com.ceco.kitkat.gravitybox.preference.OngoingNotifPreference
+		<com.ceco.kitkat.gravitybox.preference.OngoingNotifPreference
             android:key="pref_ongoing_notifications"
             android:title="@string/pref_ongoing_notifications_title"
             android:summary="@string/pref_ongoing_notifications_summary" />
 
-        <CheckBoxPreference 
+		<CheckBoxPreference 
             android:key="pref_statusbar_brightness"
             android:title="@string/pref_statusbar_brightness_title"
             android:summary="@string/pref_statusbar_brightness_summary"
             android:defaultValue="false" />
 
-        <CheckBoxPreference 
+		<CheckBoxPreference 
             android:key="pref_statusbar_dt2s"
             android:title="@string/pref_statusbar_dt2s_title"
             android:summary="@string/pref_statusbar_dt2s_summary"
             android:defaultValue="false" />
 
-        <CheckBoxPreference 
+		<CheckBoxPreference 
             android:key="pref_disable_roaming_indicators"
             android:title="@string/pref_disable_roaming_indicators_title"
             android:summary="@string/pref_disable_roaming_indicators_summary"
             android:defaultValue="false" />
 
-    </PreferenceScreen>
+	</PreferenceScreen>
 
-    <PreferenceScreen
+	<PreferenceScreen
         android:key="pref_cat_navigation_bar"
         android:title="@string/pref_cat_navigation_bar_title"
         android:summary="@string/pref_cat_navigation_bar_summary">
 
-        <PreferenceCategory
+		<PreferenceCategory
             android:key="pref_cat_navbar_general"
             android:title="@string/pref_cat_navbar_general_title">
 
-            <SwitchPreference 
+			<SwitchPreference 
                 android:key="pref_navbar_override"
                 android:title="@string/pref_masterswitch_title"
                 android:summary="@string/pref_navbar_override_summary"
                 android:defaultValue="false" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_navbar_enable"
                 android:title="@string/pref_navbar_enable_title"
                 android:summary="@string/pref_navbar_enable_summary" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_navbar_always_on_bottom"
                 android:title="@string/pref_navbar_always_on_bottom_title"
                 android:summary="@string/pref_navbar_always_on_bottom_summary"
                 android:defaultValue="false"
                 android:dependency="pref_navbar_override" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-        <PreferenceCategory
+		<PreferenceCategory
             android:key="pref_cat_navbar_keys"
             android:title="@string/pref_cat_navbar_keys_title">
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_navbar_menukey"
                 android:title="@string/pref_navbar_menukey_title"
                 android:defaultValue="false" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_navbar_swap_keys"
                 android:title="@string/pref_navbar_swap_keys_title"
                 android:defaultValue="false" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_navbar_cursor_control"
                 android:title="@string/pref_navbar_cursor_control_title"
                 android:summary="@string/pref_navbar_cursor_control_summary"
                 android:defaultValue="false" />
 
-            <PreferenceScreen 
+			<PreferenceScreen 
                 android:key="pref_cat_navbar_custom_key"
                 android:title="@string/pref_cat_navbar_custom_key_title">
 
-                <CheckBoxPreference 
+				<CheckBoxPreference 
                     android:key="pref_navbar_custom_key_enable"
                     android:title="@string/pref_navbar_custom_key_enable_title"
                     android:defaultValue="false" />
 
-                <ListPreference
+				<ListPreference
                     android:key="pref_navbar_custom_key_singletap"
                     android:title="@string/pref_hwkey_singletap_title"
                     android:defaultValue="12"
                     android:dependency="pref_navbar_custom_key_enable" />
 
-                <ListPreference
+				<ListPreference
                     android:key="pref_navbar_custom_key_longpress"
                     android:title="@string/pref_hwkey_longpress_title"
                     android:defaultValue="0"
                     android:dependency="pref_navbar_custom_key_enable" />
 
-                <ListPreference
+				<ListPreference
                     android:key="pref_navbar_custom_key_doubletap"
                     android:title="@string/pref_hwkey_doubletap_title"
                     android:defaultValue="0"
                     android:dependency="pref_navbar_custom_key_enable" />
 
-                <CheckBoxPreference 
+				<CheckBoxPreference 
                     android:key="pref_navbar_custom_key_swap"
                     android:title="@string/pref_navbar_custom_key_swap_title"
                     android:defaultValue="false"
                     android:dependency="pref_navbar_custom_key_enable" />
 
-            </PreferenceScreen>
+			</PreferenceScreen>
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-        <PreferenceCategory 
+		<PreferenceCategory 
             android:key="pref_cat_navbar_ring"
             android:title="@string/pref_cat_navbar_ring_title">
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_navbar_ring_disable"
                 android:title="@string/pref_navbar_ring_disable_title"
                 android:defaultValue="false"
                 android:disableDependentsState="true" />
 
-            <PreferenceScreen 
+			<PreferenceScreen 
                 android:key="pref_cat_navbar_ring_targets"
                 android:title="@string/pref_cat_navbar_ring_targets_title"
                 android:dependency="pref_navbar_ring_disable" >
 
-                <SwitchPreference 
+				<SwitchPreference 
                     android:key="pref_navbar_ring_targets_enable"
                     android:title="@string/pref_masterswitch_title"
                     android:summary="@string/pref_navbar_ring_targets_enable_summary"
                     android:defaultValue="false" />
 
-                <!-- Ring target prefs will be generated dynamically at runtime -->
+				<!-- Ring target prefs will be generated dynamically at runtime -->
 
-                <ListPreference
+				<ListPreference
                     android:key="pref_navbar_ring_targets_bg_style"
                     android:title="@string/pref_navbar_ring_targets_bg_style_title"
                     android:entries="@array/nrt_bg_style_entries"
@@ -940,7 +944,7 @@
                     android:defaultValue="NONE"
                     android:dependency="pref_navbar_ring_targets_enable" />
 
-                <ListPreference
+				<ListPreference
                     android:key="pref_navbar_ring_haptic_feedback"
                     android:title="@string/pref_navbar_ring_haptic_feedback_title"
                     android:entries="@array/navring_haptic_feedback_entries"
@@ -948,48 +952,48 @@
                     android:defaultValue="DEFAULT"
                     android:dependency="pref_navbar_ring_targets_enable" />
 
-            </PreferenceScreen>
+			</PreferenceScreen>
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-        <PreferenceCategory
+		<PreferenceCategory
             android:key="pref_cat_navbar_color"
             android:title="@string/pref_cat_navbar_color_title">
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_navbar_color_enable"
                 android:title="@string/pref_navbar_color_enable_title"
                 android:summary="@string/pref_navbar_color_enable_summary"
                 android:defaultValue="false" />
 
-            <net.margaritov.preference.colorpicker.ColorPickerPreference 
+			<net.margaritov.preference.colorpicker.ColorPickerPreference 
                 android:key="pref_navbar_key_color"
                 android:title="@string/pref_navbar_key_color_title"
                 android:defaultValue="@color/navbar_key_color"
                 android:dependency="pref_navbar_color_enable"
                 alphaSlider="false" />
 
-            <net.margaritov.preference.colorpicker.ColorPickerPreference 
+			<net.margaritov.preference.colorpicker.ColorPickerPreference 
                 android:key="pref_navbar_key_glow_color"
                 android:title="@string/pref_navbar_key_glow_color_title"
                 android:defaultValue="@color/navbar_key_glow_color"
                 android:dependency="pref_navbar_color_enable"
                 alphaSlider="true" />
 
-            <net.margaritov.preference.colorpicker.ColorPickerPreference 
+			<net.margaritov.preference.colorpicker.ColorPickerPreference 
                 android:key="pref_navbar_bg_color"
                 android:title="@string/pref_navbar_bg_color_title"
                 android:defaultValue="@color/navbar_bg_color"
                 android:dependency="pref_navbar_color_enable"
                 alphaSlider="false" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-        <PreferenceCategory
+		<PreferenceCategory
             android:key="pref_cat_navbar_dimen"
             android:title="@string/pref_cat_navbar_dimen_title">
 
-            <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+			<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                 android:key="pref_navbar_height"
                 android:title="@string/pref_navbar_height_title"
                 android:summary="@string/pref_navbar_height_summary"
@@ -1000,7 +1004,7 @@
                 monitorBoxUnit="%"
                 android:defaultValue="100" />
 
-            <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+			<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                 android:key="pref_navbar_height_landscape"
                 android:title="@string/pref_navbar_height_title"
                 android:summary="@string/pref_navbar_height_landscape_summary"
@@ -1011,7 +1015,7 @@
                 monitorBoxUnit="%"
                 android:defaultValue="100" />
 
-            <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+			<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                 android:key="pref_navbar_width"
                 android:title="@string/pref_navbar_width_title"
                 android:summary="@string/pref_navbar_width_summary"
@@ -1022,42 +1026,42 @@
                 monitorBoxUnit="%"
                 android:defaultValue="100" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-    </PreferenceScreen>
+	</PreferenceScreen>
 
-    <PreferenceScreen
+	<PreferenceScreen
         android:key="pref_cat_pie_control"
         android:title="@string/pie_control_title"
         android:summary="@string/pie_control_summary">
 
-        <ListPreference 
+		<ListPreference 
             android:key="pref_pie_control_enable2"
             android:title="@string/pie_control_enable_title"
             android:entries="@array/pie_controls_enable_entries"
             android:entryValues="@array/pie_controls_enable_values"
             android:defaultValue="0" />
 
-        <ListPreference 
+		<ListPreference 
             android:key="pref_pie_control_custom_key"
             android:title="@string/pref_pie_control_custom_key_title"
             android:entries="@array/pie_custom_key_entries"
             android:entryValues="@array/pie_custom_key_values"
             android:defaultValue="0" />
 
-        <CheckBoxPreference 
+		<CheckBoxPreference 
             android:key="pref_pie_control_menu"
             android:title="@string/pie_control_menu_title"
             android:defaultValue="false" />
 
-        <MultiSelectListPreference
+		<MultiSelectListPreference
             android:key="pref_pie_control_trigger_positions"
             android:title="@string/pie_control_trigger_positions_title"
             android:entries="@array/pie_control_trigger_position_entries"
             android:entryValues="@array/pie_control_trigger_position_values"
             android:defaultValue="@array/pie_control_trigger_position_default" />
 
-        <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+		<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                 android:key="pref_pie_control_trigger_size"
                 android:title="@string/pie_control_trigger_size_title"
                 minimum="2"
@@ -1067,7 +1071,7 @@
                 monitorBoxUnit="px"
                 android:defaultValue="5" />
 
-        <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+		<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                 android:key="pref_pie_control_size"
                 android:title="@string/pie_control_size_title"
                 minimum="500"
@@ -1075,109 +1079,109 @@
                 interval="10"
                 android:defaultValue="1000" />
 
-        <CheckBoxPreference 
+		<CheckBoxPreference 
                 android:key="pref_pie_sysinfo_disable"
                 android:title="@string/pref_pie_sysinfo_disable_title"
                 android:defaultValue="false" />
 
-        <CheckBoxPreference 
+		<CheckBoxPreference 
                 android:key="pref_hwkeys_disable"
                 android:title="@string/pref_hwkeys_disable_title"
                 android:summary="@string/pref_hwkeys_disable_summary"
                 android:defaultValue="false" />
 
-        <PreferenceCategory
+		<PreferenceCategory
             android:key="pref_cat_pie_long_press"
             android:title="@string/pref_cat_pie_long_press_title" >
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_pie_back_longpress"
                 android:title="@string/pref_pie_back_longpress_title"
                 android:defaultValue="0"/>
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_pie_home_longpress"
                 android:title="@string/pref_pie_home_longpress_title"
                 android:defaultValue="0"/>
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_pie_recents_longpress"
                 android:title="@string/pref_pie_recents_longpress_title"
                 android:defaultValue="0"/>
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_pie_search_longpress"
                 android:title="@string/pref_pie_search_longpress_title"
                 android:defaultValue="0"/>
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_pie_menu_longpress"
                 android:title="@string/pref_pie_menu_longpress_title"
                 android:defaultValue="0"/>
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_pie_app_longpress"
                 android:title="@string/pref_pie_app_longpress_title"
                 android:defaultValue="0"/>
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_pie_longpress_delay"
                 android:title="@string/pref_pie_longpress_delay_title"
                 android:entries="@array/pie_longpress_delay_entries"
                 android:entryValues="@array/pie_longpress_delay_values"
                 android:defaultValue="0"/>
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-        <PreferenceCategory
+		<PreferenceCategory
             android:key="pref_cat_pie_colors"
             android:title="@string/pref_cat_pie_colors_title">
 
-            <net.margaritov.preference.colorpicker.ColorPickerPreference 
+			<net.margaritov.preference.colorpicker.ColorPickerPreference 
                 android:key="pref_pie_color_bg"
                 android:title="@string/pref_pie_color_bg_title"
                 android:defaultValue="@color/pie_background_color"
                 alphaSlider="true" />
 
-            <net.margaritov.preference.colorpicker.ColorPickerPreference 
+			<net.margaritov.preference.colorpicker.ColorPickerPreference 
                 android:key="pref_pie_color_fg"
                 android:title="@string/pref_pie_color_fg_title"
                 android:defaultValue="@color/pie_foreground_color"
                 alphaSlider="false" />
 
-            <net.margaritov.preference.colorpicker.ColorPickerPreference 
+			<net.margaritov.preference.colorpicker.ColorPickerPreference 
                 android:key="pref_pie_color_outline"
                 android:title="@string/pref_pie_color_outline_title"
                 android:defaultValue="@color/pie_outline_color"
                 alphaSlider="true" />
 
-            <net.margaritov.preference.colorpicker.ColorPickerPreference 
+			<net.margaritov.preference.colorpicker.ColorPickerPreference 
                 android:key="pref_pie_color_selected"
                 android:title="@string/pref_pie_color_selected_title"
                 android:defaultValue="@color/pie_selected_color"
                 alphaSlider="true" />
 
-            <net.margaritov.preference.colorpicker.ColorPickerPreference 
+			<net.margaritov.preference.colorpicker.ColorPickerPreference 
                 android:key="pref_pie_color_text"
                 android:title="@string/pref_pie_color_text_title"
                 android:defaultValue="@color/pie_text_color"
                 alphaSlider="false" />
 
-            <Preference
+			<Preference
                 android:key="pref_pie_color_reset"
                 android:title="@string/pref_pie_color_reset_title"
                 android:persistent="false" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-        </PreferenceScreen>
+	</PreferenceScreen>
 
-    <PreferenceScreen 
+	<PreferenceScreen 
         android:key="pref_cat_transparency_manager"
         android:title="@string/pref_cat_transparency_manager_title"
         android:summary="@string/pref_cat_transparency_manager_summary">
 
-        <ListPreference
+		<ListPreference
             android:key="pref_tm_mode" 
             android:title="@string/pref_tm_mode_title"
             android:summary="@string/pref_tm_mode_summary"
@@ -1185,7 +1189,7 @@
             android:entryValues="@array/tm_mode_values"
             android:defaultValue="3" />
 
-        <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+		<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
             android:key="pref_tm_statusbar_launcher"
             android:title="@string/pref_tm_statusbar_launcher_title"
             minimum="0"
@@ -1194,7 +1198,7 @@
             monitorBoxEnabled="true"
             monitorBoxUnit="%" />
 
-        <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+		<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
             android:key="pref_tm_statusbar_lockscreen"
             android:title="@string/pref_tm_statusbar_lockscreen_title"
             minimum="0"
@@ -1203,7 +1207,7 @@
             monitorBoxEnabled="true"
             monitorBoxUnit="%" />
 
-        <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+		<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
             android:key="pref_tm_navbar_launcher"
             android:title="@string/pref_tm_navbar_launcher_title"
             minimum="0"
@@ -1212,7 +1216,7 @@
             monitorBoxEnabled="true"
             monitorBoxUnit="%" />
 
-        <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+		<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
             android:key="pref_tm_navbar_lockscreen"
             android:title="@string/pref_tm_navbar_lockscreen_title"
             minimum="0"
@@ -1221,114 +1225,114 @@
             monitorBoxEnabled="true"
             monitorBoxUnit="%" />
 
-    </PreferenceScreen>
+	</PreferenceScreen>
 
-    <PreferenceScreen
+	<PreferenceScreen
         android:key="pref_cat_power"
         android:title="@string/pref_cat_power_title"
         android:summary="@string/pref_cat_power_summary">
 
-        <PreferenceCategory 
+		<PreferenceCategory 
             android:key="pref_cat_power_menu"
             android:title="@string/pref_cat_power_menu_title">
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_powermenu_disable_on_lockscreen"
                 android:title="@string/pref_powermenu_disable_on_lockscreen_title"
                 android:defaultValue="false" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_poweroff_advanced"
                 android:title="@string/poweroff_advanced_title"
                 android:summary="@string/poweroff_advanced_summary"
                 android:defaultValue="false" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_reboot_allow_on_lockscreen"
                 android:title="@string/pref_reboot_allow_on_lockscreen_title"
                 android:defaultValue="false"
                 android:dependency="pref_poweroff_advanced" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_reboot_confirm_required"
                 android:title="@string/pref_reboot_confirm_required_title"
                 android:defaultValue="true"
                 android:dependency="pref_poweroff_advanced" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_powermenu_screenshot"
                 android:title="@string/pref_powermenu_screenshot_title"
                 android:defaultValue="false" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_powermenu_screenrecord"
                 android:title="@string/pref_powermenu_screenrecord_title"
                 android:defaultValue="false" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-        <PreferenceCategory 
+		<PreferenceCategory 
             android:key="pref_cat_power_other"
             android:title="@string/pref_cat_power_other_title">
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_low_battery_warning_policy"
                 android:title="@string/low_battery_warning_policy_title"
                 android:entries="@array/low_battery_warning_policy_entries"
                 android:entryValues="@array/low_battery_warning_policy_values"
                 android:defaultValue="3" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_battery_charged_sound"
                 android:title="@string/pref_battery_charged_sound_title"
                 android:summary="@string/pref_battery_charged_sound_summary"
                 android:defaultValue="false" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_charger_plugged_sound"
                 android:title="@string/pref_charger_plugged_sound_title"
                 android:summary="@string/pref_charger_plugged_sound_summary"
                 android:defaultValue="false" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_flashing_led_disable"
                 android:title="@string/pref_flashing_led_disable_title"
                 android:summary="@string/pref_flashing_led_disable_summary"
                 android:defaultValue="false" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_charging_led_disable"
                 android:title="@string/pref_charging_led_disable_title"
                 android:summary="@string/pref_charging_led_disable_summary"
                 android:defaultValue="false" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-    </PreferenceScreen>
+	</PreferenceScreen>
 
-    <PreferenceScreen 
+	<PreferenceScreen 
         android:key="pref_cat_display"
         android:title="@string/pref_cat_display_title"
         android:summary="@string/pref_cat_display_summary">
 
-        <ListPreference
+		<ListPreference
             android:key="pref_expanded_desktop"
             android:title="@string/pref_expanded_desktop_title"
             android:entries="@array/expanded_desktop_entries"
             android:entryValues="@array/expanded_desktop_values"
             android:defaultValue="0" />
 
-        <PreferenceScreen
+		<PreferenceScreen
             android:key="pref_cat_brightness"
             android:title="@string/pref_cat_brightness_title">
 
-            <SwitchPreference 
+			<SwitchPreference 
                 android:key="pref_brightness_master_switch"
                 android:title=""
                 android:summary="@string/pref_brightness_master_switch_summary"
                 android:defaultValue="false" />
 
-            <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+			<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                 android:key="pref_brightness_min2"
                 android:title="@string/pref_brightness_min_title"
                 android:summary="@string/pref_brightness_min_summary"
@@ -1339,7 +1343,7 @@
                 android:defaultValue="20"
                 android:dependency="pref_brightness_master_switch" />
 
-            <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+			<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                 android:key="pref_screen_dim_level"
                 android:title="@string/pref_screen_dim_level_title"
                 android:summary="@string/pref_screen_dim_level_summary"
@@ -1350,44 +1354,44 @@
                 android:defaultValue="10"
                 android:dependency="pref_brightness_master_switch" />
 
-            <com.ceco.kitkat.gravitybox.preference.AutoBrightnessDialogPreference
+			<com.ceco.kitkat.gravitybox.preference.AutoBrightnessDialogPreference
                 android:key="pref_autobrightness" 
                 android:title="@string/pref_ab_title"
                 android:summary="@string/pref_ab_summary"
                 android:dependency="pref_brightness_master_switch" />
 
-        </PreferenceScreen>
+		</PreferenceScreen>
 
-        <CheckBoxPreference 
+		<CheckBoxPreference 
             android:key="pref_display_allow_all_rotations"
             android:title="@string/pref_display_allow_all_rotations_title"
             android:defaultValue="false" />
 
-        <ListPreference 
+		<ListPreference 
             android:key="pref_crt_off_effect2"
             android:title="@string/crt_off_effect_title"
             android:entries="@array/screen_off_effect_entries"
             android:entryValues="@array/screen_off_effect_values"
             android:defaultValue="0" />
 
-        <CheckBoxPreference 
+		<CheckBoxPreference 
             android:key="pref_unplug_turns_on_screen"
             android:title="@string/pref_unplug_turns_on_screen_title"
             android:summary="@string/pref_unplug_turns_on_screen_summary" />
 
-        <CheckBoxPreference
+		<CheckBoxPreference
             android:key="pref_holo_bg_dither"
             android:title="@string/pref_holo_bg_dither_title"
             android:summary="@string/pref_holo_bg_dither_summary"
             android:defaultValue="false" />
 
-        <CheckBoxPreference
+		<CheckBoxPreference
             android:key="pref_holo_bg_solid_black"
             android:title="@string/pref_holo_bg_solid_black_title"
             android:summary="@string/pref_holo_bg_solid_black_summary"
             android:defaultValue="false" />
 
-        <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+		<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
             android:key="pref_pulse_notification_delay"
             android:title="@string/pref_pulse_notification_delay_title"
             android:summary="@string/pref_pulse_notification_delay_summary"
@@ -1397,38 +1401,38 @@
             monitorBoxEnabled="true"
             monitorBoxUnit="s" />
 
-        <ListPreference
+		<ListPreference
             android:key="pref_button_backlight_mode"
             android:title="@string/pref_button_backlight_mode_title"
             android:entries="@array/button_backlight_mode_entries"
             android:entryValues="@array/button_backlight_mode_values"
             android:defaultValue="default" />
 
-        <CheckBoxPreference
+		<CheckBoxPreference
             android:key="pref_button_backlight_notifications"
             android:title="@string/pref_button_backlight_notifications_title"
             android:summary="@string/pref_button_backlight_notifications_summary"
             android:defaultValue="false" />
 
-        <ListPreference
+		<ListPreference
             android:key="pref_translucent_decor"
             android:title="@string/pref_translucent_decor_title"
             android:entries="@array/pref_translucent_decor_entries"
             android:entryValues="@array/pref_translucent_decor_values"
             android:defaultValue="0" />
 
-    </PreferenceScreen>
+	</PreferenceScreen>
 
-    <PreferenceScreen 
+	<PreferenceScreen 
         android:key="pref_cat_phone"
         android:title="@string/pref_cat_phone_title"
         android:summary="@string/pref_cat_phone_summary">
 
-        <PreferenceCategory
+		<PreferenceCategory
             android:key="pref_cat_phone_telephony"
             android:title="@string/pref_cat_phone_telephony_title">
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_phone_flip"
                 android:title="@string/pref_phone_flip_title"
                 android:summary="@string/pref_phone_flip_summary"
@@ -1436,44 +1440,44 @@
                 android:entryValues="@array/phone_flip_action_values"
                 android:defaultValue="0" />
 
-            <MultiSelectListPreference 
+			<MultiSelectListPreference 
                 android:key="pref_call_vibrations"
                 android:title="@string/pref_call_vibrations_title"
                 android:entries="@array/call_vibration_entries"
                 android:entryValues="@array/call_vibration_values"
                 android:defaultValue="@array/empty_array" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_phone_nonintrusive_incoming_call"
                 android:title="@string/pref_phone_nonintrusive_incoming_call_title"
                 android:summary="@string/pref_phone_nonintrusive_incoming_call_summary"
                 android:defaultValue="false" />
 
-            <ListPreference 
+			<ListPreference 
                 android:key="pref_caller_fullscreen_photo2"
                 android:title="@string/caller_fullscreen_photo_title"
                 android:entries="@array/fullscreen_caller_entries"
                 android:entryValues="@array/fullscreen_caller_values"
                 android:defaultValue="disabled" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_caller_unknown_photo_enable"
                 android:title="@string/pref_caller_unknown_photo_enable_title"
                 android:defaultValue="false" />
 
-            <Preference
+			<Preference
                 android:key="pref_caller_unknown_photo"
                 android:title="@string/pref_caller_unknown_photo_title" />
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_dialer_show_dialpad"
                 android:title="@string/pref_dialer_show_dialpad_title"
                 android:summary="@string/pref_dialer_show_dialpad_summary"
                 android:defaultValue="false" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-        <!--
+		<!--
         <PreferenceCategory
             android:key="pref_cat_phone_messaging"
             android:title="@string/pref_cat_phone_messaging_title">
@@ -1481,35 +1485,35 @@
         </PreferenceCategory>
         -->
 
-        <PreferenceCategory 
+		<PreferenceCategory 
             android:key="pref_cat_phone_mobile_data"
             android:title="@string/pref_cat_phone_mobile_data_title">
 
-            <PreferenceScreen
+			<PreferenceScreen
                 android:key="pref_cat_smart_radio"
                 android:title="@string/pref_cat_smart_radio_title" >
 
-                <SwitchPreference
+				<SwitchPreference
                     android:key="pref_smart_radio_enable"
                     android:title="@string/pref_masterswitch_title"
                     android:summary="@string/pref_smart_radio_enable_summary"
                     android:defaultValue="false" />
 
-                <com.ceco.kitkat.gravitybox.preference.NetworkModePreference
+				<com.ceco.kitkat.gravitybox.preference.NetworkModePreference
                     android:key="pref_smart_radio_normal_mode"
                     android:title="@string/pref_smart_radio_normal_mode_title"
                     android:summary="@string/smart_radio_action_undefined"
                     android:defaultValue="-1"
                     android:dependency="pref_smart_radio_enable" />
 
-                <com.ceco.kitkat.gravitybox.preference.NetworkModePreference
+				<com.ceco.kitkat.gravitybox.preference.NetworkModePreference
                     android:key="pref_smart_radio_power_saving_mode"
                     android:title="@string/pref_smart_radio_power_saving_mode_title"
                     android:summary="@string/smart_radio_action_undefined"
                     android:defaultValue="-1"
                     android:dependency="pref_smart_radio_enable" />
 
-                <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+				<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                     android:key="pref_smart_radio_mode_change_delay"
                     android:title="@string/pref_smart_radio_mode_change_delay_title"
                     android:summary="@string/pref_smart_radio_mode_change_delay_summary"
@@ -1521,14 +1525,14 @@
                     android:defaultValue="5"
                     android:dependency="pref_smart_radio_enable" />
 
-                <CheckBoxPreference 
+				<CheckBoxPreference 
                     android:key="pref_smart_radio_screen_off"
                     android:title="@string/pref_smart_radio_screen_off_title"
                     android:summary="@string/pref_smart_radio_screen_off_summary"
                     android:defaultValue="false"
                     android:dependency="pref_smart_radio_enable" />
 
-                <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+				<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                     android:key="pref_smart_radio_screen_off_delay"
                     android:title="@string/pref_smart_radio_screen_off_delay_title"
                     android:summary="@string/pref_smart_radio_screen_off_delay_summary"
@@ -1540,182 +1544,182 @@
                     android:defaultValue="0"
                     android:dependency="pref_smart_radio_screen_off" />
 
-                <CheckBoxPreference 
+				<CheckBoxPreference 
                     android:key="pref_smart_radio_ignore_locked"
                     android:title="@string/pref_smart_radio_ignore_locked_title"
                     android:summary="@string/pref_smart_radio_ignore_locked_summary"
                     android:defaultValue="true"
                     android:dependency="pref_smart_radio_screen_off" />
 
-            </PreferenceScreen>
+			</PreferenceScreen>
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_national_roaming"
                 android:title="@string/pref_national_roaming_title"
                 android:summary="@string/pref_national_roaming_summary"
                 android:defaultValue="false" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-    </PreferenceScreen>
+	</PreferenceScreen>
 
-    <PreferenceScreen 
+	<PreferenceScreen 
         android:key="pref_cat_media"
         android:title="@string/pref_cat_media_title"
         android:summary="@string/pref_cat_media_summary">
 
-        <CheckBoxPreference 
+		<CheckBoxPreference 
             android:key="pref_vol_music_controls"
             android:title="@string/vol_music_controls_title"
             android:summary="@string/vol_music_controls_summary"
             android:defaultValue="false" />
 
-        <CheckBoxPreference 
+		<CheckBoxPreference 
             android:key="pref_music_volume_steps"
             android:title="@string/pref_music_volume_steps_title"
             android:summary="@string/pref_music_volume_steps_summary"
             android:defaultValue="false" />
 
-        <CheckBoxPreference 
+		<CheckBoxPreference 
             android:key="pref_vol_force_music_control"
             android:title="@string/pref_vol_force_music_control_title"
             android:summary="@string/pref_vol_force_music_control_summary"
             android:defaultValue="false" />
 
-        <CheckBoxPreference
+		<CheckBoxPreference
             android:key="pref_vol_swap_keys"
             android:title="@string/pref_vol_swap_keys_title"
             android:summary="@string/pref_vol_swap_keys_summary"
             android:defaultValue="false" />
 
-        <CheckBoxPreference 
+		<CheckBoxPreference 
             android:key="pref_safe_media_volume"
             android:title="@string/pref_safe_media_volume_title"
             android:summary="@string/pref_safe_media_volume_summary"
             android:defaultValue="false" />
 
-        <CheckBoxPreference 
+		<CheckBoxPreference 
             android:key="pref_volume_panel_expandable"
             android:title="@string/pref_volume_panel_expandable_title"
             android:summary="@string/pref_volume_panel_expandable_summary"
             android:defaultValue="false" />
 
-        <CheckBoxPreference
+		<CheckBoxPreference
             android:key="pref_volume_panel_expand_fully"
             android:title="@string/pref_volume_panel_expandable_fully_title"
             android:summary="@string/pref_volume_panel_expandable_fully_summary"
             android:defaultValue="false" />
 
-        <CheckBoxPreference
+		<CheckBoxPreference
             android:defaultValue="false"
             android:key="pref_volume_panel_autoexpand"
             android:title="@string/pref_volume_panel_autoexpand_title" />
 
-        <CheckBoxPreference 
+		<CheckBoxPreference 
             android:key="pref_link_volumes"
             android:title="@string/pref_link_volumes_title"
             android:summary="@string/pref_link_volumes_summary"
             android:defaultValue="true" />
 
-        <CheckBoxPreference 
+		<CheckBoxPreference 
             android:key="pref_volume_adjust_mute"
             android:title="@string/pref_volume_adjust_mute_title"
             android:summary="@string/pref_volume_adjust_mute_summary"
             android:defaultValue="false" />
 
-        <CheckBoxPreference 
+		<CheckBoxPreference 
             android:key="pref_volume_adjust_vibrate_mute"
             android:title="@string/pref_volume_adjust_vibrate_mute_title"
             android:summary="@string/pref_volume_adjust_vibrate_mute_summary"
             android:defaultValue="false" />
 
-        <ListPreference
+		<ListPreference
             android:key="pref_volume_panel_timeout"
             android:title="@string/pref_volume_panel_timeout_title"
             android:entries="@array/volume_panel_timeout_entries"
             android:entryValues="@array/volume_panel_timeout_values"
             android:defaultValue="3000" />
 
-    </PreferenceScreen>
+	</PreferenceScreen>
 
-    <PreferenceScreen 
+	<PreferenceScreen 
         android:key="pref_cat_launcher_tweaks"
         android:title="@string/pref_cat_launcher_tweaks_title"
         android:summary="@string/pref_cat_launcher_tweaks_summary">
 
-        <PreferenceCategory 
+		<PreferenceCategory 
             android:key="pref_cat_launcher_desktop_grid"
             android:title="@string/pref_cat_launcher_desktop_grid_title">
 
-            <Preference 
+			<Preference 
                 android:key="pref_launcher_desktop_grid_info"
                 android:summary="@string/pref_launcher_desktop_grid_info_title"
                 android:persistent="false" />
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_launcher_desktop_grid_rows" 
                 android:title="@string/pref_launcher_desktop_grid_rows_title"
                 android:entries="@array/desktop_grid_row_entries"
                 android:entryValues="@array/desktop_grid_row_values"
                 android:defaultValue="0" />
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_launcher_desktop_grid_cols" 
                 android:title="@string/pref_launcher_desktop_grid_cols_title"
                 android:entries="@array/desktop_grid_col_entries"
                 android:entryValues="@array/desktop_grid_col_values"
                 android:defaultValue="0" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-        <PreferenceCategory 
+		<PreferenceCategory 
             android:key="pref_cat_launcher_other"
             android:title="@string/pref_cat_launcher_other_title">
 
-            <CheckBoxPreference 
+			<CheckBoxPreference 
                 android:key="pref_launcher_resize_widget"
                 android:title="@string/pref_launcher_resize_widget_title"
                 android:summary="@string/pref_launcher_resize_widget_summary"
                 android:defaultValue="false" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-    </PreferenceScreen>
+	</PreferenceScreen>
 
-    <PreferenceScreen 
+	<PreferenceScreen 
         android:key="pref_cat_hwkey_actions"
         android:title="@string/pref_cat_hwkey_actions_title"
         android:summary="@string/pref_cat_hwkey_actions_summary">
 
-        <PreferenceCategory
+		<PreferenceCategory
             android:key="pref_cat_hwkey_menu"
             android:title="@string/pref_cat_hwkey_menu_title">
-            
-            <ListPreference
+
+			<ListPreference
                 android:key="pref_hwkey_menu_longpress"
                 android:title="@string/pref_hwkey_longpress_title"
                 android:dialogTitle="@string/hwkey_menu_longpress_dialog_title"
                 android:defaultValue="0"/>
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_hwkey_menu_doubletap"
                 android:title="@string/pref_hwkey_doubletap_title"
                 android:dialogTitle="@string/hwkey_menu_doubletap_dialog_title"
                 android:defaultValue="0"/>
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-        <PreferenceCategory
+		<PreferenceCategory
             android:key="pref_cat_hwkey_home"
             android:title="@string/pref_cat_hwkey_home_title">
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_hwkey_home_longpress"
                 android:title="@string/pref_hwkey_longpress_title"
                 android:dialogTitle="@string/hwkey_home_longpress_dialog_title"
                 android:defaultValue="0"/>
 
-            <!-- 
+			<!-- 
             <CheckBoxPreference
                 android:key="pref_hwkey_home_longpress_keyguard"
                 android:title="@string/pref_hwkey_home_longpress_keyguard_title"
@@ -1723,61 +1727,61 @@
                 android:defaultValue="false" />
             -->
 
-            <CheckBoxPreference
+			<CheckBoxPreference
                 android:key="pref_hwkey_home_doubletap_disable"
                 android:title="@string/pref_hwkey_doubletap_disable_title"
                 android:defaultValue="false"
                 android:disableDependentsState="true" />
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_hwkey_home_doubletap"
                 android:title="@string/pref_hwkey_doubletap_title"
                 android:defaultValue="0"
                 android:dependency="pref_hwkey_home_doubletap_disable" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-        <PreferenceCategory
+		<PreferenceCategory
             android:key="pref_cat_hwkey_back"
             android:title="@string/pref_cat_hwkey_back_title">
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_hwkey_back_longpress"
                 android:title="@string/pref_hwkey_longpress_title"
                 android:dialogTitle="@string/hwkey_back_longpress_dialog_title"
                 android:defaultValue="0"/>
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_hwkey_back_doubletap"
                 android:title="@string/pref_hwkey_doubletap_title"
                 android:dialogTitle="@string/hwkey_back_doubletap_dialog_title"
                 android:defaultValue="0"/>
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-        <PreferenceCategory
+		<PreferenceCategory
             android:key="pref_cat_hwkey_recents"
             android:title="@string/pref_cat_hwkey_recents_title">
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_hwkey_recents_singletap"
                 android:title="@string/pref_hwkey_singletap_title"
                 android:dialogTitle="@string/hwkey_recents_singletap_dialog_title"
                 android:defaultValue="0"/>
-            
-            <ListPreference
+
+			<ListPreference
                 android:key="pref_hwkey_recents_longpress"
                 android:title="@string/pref_hwkey_longpress_title"
                 android:dialogTitle="@string/hwkey_recents_longpress_dialog_title"
                 android:defaultValue="0"/>
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-        <PreferenceCategory
+		<PreferenceCategory
             android:key="pref_cat_hwkey_volume"
             android:title="@string/pref_cat_hwkey_volume_title">
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_vol_key_cursor_control"
                 android:title="@string/vol_key_cursor_control_title"
                 android:summary="@string/vol_key_cursor_control_summary"
@@ -1785,39 +1789,39 @@
                 android:entryValues="@array/vol_key_cursor_control_values"
                 android:defaultValue="0" />
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_volume_rocker_wake"
                 android:title="@string/pref_volume_rocker_wake_title"
                 android:entries="@array/volume_rocker_wake_entries"
                 android:entryValues="@array/volume_rocker_wake_values"
                 android:defaultValue="default" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-        <PreferenceCategory
+		<PreferenceCategory
             android:key="pref_cat_hwkey_actions_others"
             android:title="@string/pref_cat_hwkey_actions_others">
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_hwkey_lockscreen_torch"
                 android:title="@string/pref_hwkey_lockscreen_torch_title"
                 android:entries="@array/hwkey_ls_torch_entries"
                 android:entryValues="@array/hwkey_ls_torch_values"
                 android:defaultValue="0" />
 
-            <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+			<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                 android:key="pref_hwkey_custom_app"
                 android:title="@string/pref_hwkey_custom_app_title"
                 android:summary="@string/app_picker_none"
                 iconPickerEnabled="false" />
 
-            <com.ceco.kitkat.gravitybox.preference.AppPickerPreference
+			<com.ceco.kitkat.gravitybox.preference.AppPickerPreference
                 android:key="pref_hwkey_custom_app2"
                 android:title="@string/pref_hwkey_custom_app_title2"
                 android:summary="@string/app_picker_none"
                 iconPickerEnabled="false" />
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_hwkey_doubletap_speed"
                 android:title="@string/pref_hwkey_doubletap_speed_title"
                 android:summary="@string/pref_hwkey_doubletap_speed_summary"
@@ -1825,7 +1829,7 @@
                 android:entryValues="@array/hwkey_doubletap_speed_values"
                 android:defaultValue="400" />
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_hwkey_kill_delay"
                 android:title="@string/pref_hwkey_kill_delay_title"
                 android:summary="@string/pref_hwkey_kill_delay_summary"
@@ -1833,39 +1837,39 @@
                 android:entryValues="@array/hwkey_kill_delay_values"
                 android:defaultValue="1000" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-    </PreferenceScreen>
+	</PreferenceScreen>
 
-    <PreferenceScreen 
+	<PreferenceScreen 
         android:key="pref_cat_app_launcher"
         android:title="@string/pref_cat_app_launcher_title"
         android:summary="@string/pref_cat_app_launcher_summary">
 
-        <!-- Application slots will be generated dynamically at runtime -->
+		<!-- Application slots will be generated dynamically at runtime -->
 
-    </PreferenceScreen>
+	</PreferenceScreen>
 
-    <PreferenceScreen
+	<PreferenceScreen
         android:key="pref_cat_screenrecord_options"
         android:title="@string/pref_cat_screenrecord_options_title"
         android:summary="@string/pref_cat_screenrecord_options_summary">
 
-        <CheckBoxPreference 
+		<CheckBoxPreference 
             android:key="pref_screenrecord_use_stock"
             android:title="@string/pref_screenrecord_use_stock_title"
             android:summary="@string/pref_screenrecord_use_stock_summary"
             android:defaultValue="false"
             android:disableDependentsState="true" />
 
-        <ListPreference
+		<ListPreference
             android:key="pref_screenrecord_size"
             android:title="@string/pref_screenrecord_size_title"
             android:entries="@array/scr_size_entries"
             android:entryValues="@array/scr_size_values"
             android:defaultValue="default" />
 
-        <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+		<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
             android:key="pref_screenrecord_bitrate"
             android:title="@string/pref_screenrecord_bitrate_title"
             minimum="1"
@@ -1875,7 +1879,7 @@
             monitorBoxUnit="MBps" 
             android:defaultValue="4" />
 
-        <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+		<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
             android:key="pref_screenrecord_timelimit"
             android:title="@string/pref_screenrecord_timelimit_title"
             minimum="1"
@@ -1886,52 +1890,52 @@
             android:defaultValue="3"
             android:dependency="pref_screenrecord_use_stock" />
 
-        <CheckBoxPreference 
+		<CheckBoxPreference 
             android:key="pref_screenrecord_rotate"
             android:title="@string/pref_screenrecord_rotate_title"
             android:summary="@string/pref_screenrecord_rotate_summary"
             android:defaultValue="false" />
 
-        <CheckBoxPreference 
+		<CheckBoxPreference 
             android:key="pref_screenrecord_microphone"
             android:title="@string/pref_screenrecord_microphone_title"
             android:summary="@string/pref_screenrecord_microphone_summary"
             android:defaultValue="true"
             android:dependency="pref_screenrecord_use_stock" />
 
-    </PreferenceScreen>
+	</PreferenceScreen>
 
-    <PreferenceScreen 
+	<PreferenceScreen 
         android:key="pref_cat_misc"
         android:title="@string/pref_cat_misc_title"
         android:summary="@string/pref_cat_misc_summary">
 
-        <PreferenceCategory
+		<PreferenceCategory
             android:key="pref_cat_misc_recents_panel"
             android:title="@string/pref_cat_misc_recents_panel_title">
 
-            <ListPreference 
+			<ListPreference 
                 android:key="pref_recents_clear_all2"
                 android:title="@string/recents_clear_all_title"
                 android:entries="@array/recents_clear_entries"
                 android:entryValues="@array/recents_clear_values"
                 android:defaultValue="53" />
 
-            <ListPreference 
+			<ListPreference 
                 android:key="pref_clear_recents_mode"
                 android:title="@string/pref_clear_recents_mode_title"
                 android:entries="@array/pref_clear_recents_mode_entries"
                 android:entryValues="@array/pref_clear_recents_mode_values"
                 android:defaultValue="0" />
 
-            <ListPreference 
+			<ListPreference 
                 android:key="pref_rambar"
                 android:title="@string/pref_rambar_title"
                 android:entries="@array/rambar_entries"
                 android:entryValues="@array/rambar_values"
                 android:defaultValue="0" />
 
-            <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+			<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                 android:key="pref_recent_clear_margin_top"
                 android:title="@string/pref_recent_clear_margin_top_title"
                 minimum="0"
@@ -1941,7 +1945,7 @@
                 monitorBoxUnit="px"
                 android:defaultValue="20" />
 
-            <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+			<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                 android:key="pref_recent_clear_margin_bottom"
                 android:title="@string/pref_recent_clear_margin_bottom_title"
                 minimum="0"
@@ -1951,18 +1955,18 @@
                 monitorBoxUnit="px"
                 android:defaultValue="40" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-        <PreferenceCategory
+		<PreferenceCategory
             android:key="pref_cat_misc_other"
             android:title="@string/pref_cat_misc_other_title">
 
-            <CheckBoxPreference
+			<CheckBoxPreference
                 android:key="pref_ime_fullscreen_disable"
                 android:title="@string/pref_ime_fullscreen_disable_title"
                 android:defaultValue="false" />
 
-            <com.ceco.kitkat.gravitybox.preference.SeekBarPreference
+			<com.ceco.kitkat.gravitybox.preference.SeekBarPreference
                 android:key="pref_torch_auto_off"
                 android:title="@string/pref_torch_auto_off_title"
                 android:summary="@string/pref_torch_auto_off_summary"
@@ -1973,7 +1977,7 @@
                 monitorBoxUnit="m"
                 android:defaultValue="10" />
 
-            <ListPreference
+			<ListPreference
                 android:key="pref_force_overflow_menu_button2"
                 android:title="@string/pref_force_overflow_menu_button_title"
                 android:summary="@string/pref_force_overflow_menu_button_summary"
@@ -1981,65 +1985,65 @@
                 android:entryValues="@array/overflow_menu_values"
                 android:defaultValue="default" />
 
-        </PreferenceCategory>
+		</PreferenceCategory>
 
-    </PreferenceScreen>
+	</PreferenceScreen>
 
-    <Preference
+	<Preference
         android:key="pref_dual_sim_ringer"
         android:title="@string/dual_sim_ringer_title"
         android:summary="@string/dual_sim_ringer_summary" />"
 
-    <Preference
+	<Preference
         android:key="pref_engineering_mode"
         android:title="@string/engineering_mode_title"
         android:summary="@string/engineering_mode_summary" />"
 
-    <PreferenceScreen 
+	<PreferenceScreen 
         android:key="pref_cat_about"
         android:title="@string/pref_cat_about_title">
 
-        <Preference
+		<Preference
             android:key="pref_about_gb" 
             android:summary="@string/about_gb_summary" />
 
-        <Preference
+		<Preference
             android:key="pref_about_gplus" 
             android:title="@string/pref_about_gplus_title"
             android:summary="@string/pref_about_gplus_summary" />
 
-        <Preference
+		<Preference
             android:key="pref_about_xposed"
             android:title="@string/about_xposed_title"
             android:summary="@string/about_xposed_summary" />"
 
-        <Preference
+		<Preference
             android:key="pref_about_donate"
             android:title="@string/about_donate_title"
             android:summary="@string/about_donate_summary" />
 
-        <EditTextPreference
+		<EditTextPreference
             android:key="pref_trans_verification"
             android:title="@string/pref_trans_verification_title"
             android:summary="@string/pref_trans_verification_summary" />
 
-        <CheckBoxPreference
+		<CheckBoxPreference
             android:key="pref_gb_theme_dark"
             android:title="@string/pref_gb_theme_dark_title"
             android:summary="@string/pref_gb_theme_dark_summary"
             android:persistent="false"
             android:defaultValue="false" />
 
-        <Preference
+		<Preference
             android:key="pref_settings_backup"
             android:title="@string/pref_settings_backup_title"
             android:persistent="false" />
 
-        <Preference
+		<Preference
             android:key="pref_settings_restore"
             android:title="@string/pref_settings_restore_title"
             android:persistent="false" />
 
-    </PreferenceScreen>
+	</PreferenceScreen>
 
 </PreferenceScreen>


### PR DESCRIPTION
1 ) Moved "Hide Clock" entry up
2 ) Changed entry dependencies: Hiding clock now disables settings for center clock, day of week, day of week size and AM/PM stuff.
3 ) AM/PM size now depends on AM/PM not hidden
4 ) Added master switch dependency for alarm symbol hiding

In my opinion this is more intuitive than before. Toggling the master switch off still disables all the entries as the dependencies build a hierarchical dependency path like:
Master Switch (needs to be on for) ---> Hide Clock (needs to be off for) ---> Hide AM/PM (needs to be off for) ---> AM/PM Size
