### PR TITLE
ModLauncher: Hook DeviceProfile

### DIFF
--- a/src/com/ceco/gm2/gravitybox/ModLauncher.java
+++ b/src/com/ceco/gm2/gravitybox/ModLauncher.java
@@ -15,8 +15,9 @@
 
 package com.ceco.gm2.gravitybox;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import android.app.Activity;
 import android.content.BroadcastReceiver;
@@ -32,34 +33,30 @@ import de.robv.android.xposed.XposedBridge;
 import de.robv.android.xposed.XposedHelpers;
 
 public class ModLauncher {
-    public static final String PACKAGE_NAMES = "com.google.android.googlequicksearchbox";
+	public static final List<String> PACKAGE_NAMES;
     private static final String TAG = "GB:ModLauncher";
 
-    private static final Map<String, DynamicGrid> CLASS_DYNAMIC_GRID; 
+    private static final List<String> CLASS_DEVICE_PROFILE; 
     private static final String CLASS_LAUNCHER = "com.android.launcher3.Launcher";
     private static final String CLASS_APP_WIDGET_HOST_VIEW = "android.appwidget.AppWidgetHostView";
     private static final boolean DEBUG = false;
 
     public static final String ACTION_SHOW_APP_DRAWER = "gravitybox.launcher.intent.action.SHOW_APP_DRAWER";
+    
+    // http://androidxref.com/4.4.2_r1/xref/packages/apps/Launcher3/src/com/android/launcher3/DynamicGrid.java#99
+    // DeviceProfile(String n, float w, float h, float r, float c, float is, float its, float hs, float his)
+    public static int NUMROWS = 3;
+	public static int NUMCOLUMNS = 4;
 
-    private static final class DynamicGrid {
-        Class<?> clazz;
-        String fProfile;
-        String fNumRows;
-        String fNumCols;
-        public DynamicGrid(String fp, String fnr, String fnc) {
-            fProfile = fp;
-            fNumRows = fnr;
-            fNumCols = fnc;
-        }
-    }
-
-    static {
-        CLASS_DYNAMIC_GRID = new HashMap<String, DynamicGrid>();
-        CLASS_DYNAMIC_GRID.put("com.android.launcher3.DynamicGrid",
-                new DynamicGrid("mProfile", "numRows", "numColumns"));
-        CLASS_DYNAMIC_GRID.put("nw", new DynamicGrid("Bq", "yx", "yy"));
-    }
+	static {
+		CLASS_DEVICE_PROFILE = Arrays.asList(
+				"com.android.launcher3.DeviceProfile",
+				"mz");
+		PACKAGE_NAMES = new ArrayList<String>(Arrays.asList(
+				"com.android.launcher2", "com.android.launcher3",
+				"com.google.android.googlequicksearchbox",
+				"com.cyanogenmod.trebuchet"));
+	}
 
     private static boolean mShouldShowAppDrawer;
     private static boolean mReceiverRegistered;
@@ -79,37 +76,40 @@ public class ModLauncher {
     }
 
     public static void init(final XSharedPreferences prefs, final ClassLoader classLoader) {
-        for (String className : CLASS_DYNAMIC_GRID.keySet()) {
-            final DynamicGrid dynamicGrid;
-            try {
-                Class<?> cls = XposedHelpers.findClass(className, classLoader);
-                if (DEBUG) log("Found DynamicGrid class as: " + className);
-                dynamicGrid = CLASS_DYNAMIC_GRID.get(className);
-                dynamicGrid.clazz = cls;
-            } catch (Throwable t) { continue; }
+    	
+		Class<?> cls = null;
+		for (String className : CLASS_DEVICE_PROFILE) {
 
-            try {
-                XposedBridge.hookAllConstructors(dynamicGrid.clazz, new XC_MethodHook() { 
-                    @Override
-                    protected void afterHookedMethod(final MethodHookParam param) throws Throwable {
-                        prefs.reload();
-                        Object profile = XposedHelpers.getObjectField(param.thisObject, dynamicGrid.fProfile);
-                        if (profile != null) {
-                            final int rows = Integer.valueOf(prefs.getString(
-                                    GravityBoxSettings.PREF_KEY_LAUNCHER_DESKTOP_GRID_ROWS, "0"));
-                            if (rows != 0) {
-                                XposedHelpers.setIntField(profile, dynamicGrid.fNumRows, rows);
-                                if (DEBUG) log("Launcher rows set to: " + rows);
-                            }
-                            final int cols = Integer.valueOf(prefs.getString(
-                                    GravityBoxSettings.PREF_KEY_LAUNCHER_DESKTOP_GRID_COLS, "0"));
-                            if (cols != 0) {
-                                XposedHelpers.setIntField(profile, dynamicGrid.fNumCols, cols);
-                                if (DEBUG) log("Launcher cols set to: " + cols);
-                            }
-                        }
-                    }
-                });
+			try {
+				cls = XposedHelpers.findClass(className, classLoader);
+				if (DEBUG) log("Found DeviceProfile class as: " + className);
+			} catch (Throwable t) {
+				continue;
+			}
+
+			try {
+				XposedBridge.hookAllConstructors(cls, new XC_MethodHook() {
+
+					@Override
+					protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+
+						// making sure to only hook to the appropriate constructor
+						if (!(param.args[0] instanceof Context)) return;
+
+						prefs.reload();
+
+						final int rows = Integer.valueOf(prefs.getString(GravityBoxSettings.PREF_KEY_LAUNCHER_DESKTOP_GRID_ROWS, "0"));
+						if (rows != 0) {
+							param.args[NUMROWS] = rows;
+							if (DEBUG) log("Launcher rows set to: " + rows);
+						}
+						final int cols = Integer.valueOf(prefs.getString(GravityBoxSettings.PREF_KEY_LAUNCHER_DESKTOP_GRID_COLS, "0"));
+						if (cols != 0) {
+							param.args[NUMCOLUMNS] = cols;
+							if (DEBUG) log("Launcher cols set to: " + cols);
+						}
+					}
+				});
             } catch (Throwable t) {
                 XposedBridge.log(t);
             }


### PR DESCRIPTION
It's actually better to hook DeviceProfile. You can hook the DeviceProfile constructor which has cols and rows as parameters in it's method interface. This way you can change the values with param.args[x] instead of actually knowing the name of the variable.

With GNL being obfuscated now you only need to know the name of the DeviceProfil class if you use my approach. You can easily find the class by searching for "All Device Profiles must have an odd number of hotseat spaces" which is a [RuntimeException](http://androidxref.com/4.4.2_r1/xref/packages/apps/Launcher3/src/com/android/launcher3/DynamicGrid.java#103) thrown in this class.

You can find the source code of DeviceProfile on [Android XREF](http://androidxref.com/4.4.2_r1/xref/packages/apps/Launcher3/src/com/android/launcher3/DynamicGrid.java#54).

I haven't been able to test it since GB refused to launch "GravityBox System Framework is not responding". But it should work and it's the same implementation used in [Xposed GEL Settings](https://github.com/theknut/XposedGELSettings/blob/master/src/de/theknut/xposedgelsettings/hooks/Homescreen/DeviceProfileConstructorHook.java#L14).

I also added [Trebuchet](https://github.com/CyanogenMod/android_packages_apps_Trebuchet/blob/cm-11.0/src/com/android/launcher3/DynamicGrid.java#L57) as it's using the same launcher base. If you keep it, make sure to also edit the strings for the settings fragment.
