### PR TITLE
Updated layout in UNC quick search box to allow inputting non-English characters

### DIFF
--- a/res/layout/led_control_activity.xml
+++ b/res/layout/led_control_activity.xml
@@ -33,7 +33,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="@string/app_picker_search"
-        android:inputType="textVisiblePassword"
+        android:inputType="text"
         android:saveEnabled="false"
         android:visibility="gone" />
 


### PR DESCRIPTION
Can't search using any non-English characters at the moment...
Sometimes makes it difficult for non-English users to quickly scroll to the desired app in UNC
This edit should be enough to allow non-English characters to be inputted
