### PR TITLE
Fix for Statusbar Brightness Control

### DIFF
--- a/src/com/ceco/kitkat/gravitybox/ModStatusBar.java
+++ b/src/com/ceco/kitkat/gravitybox/ModStatusBar.java
@@ -480,7 +480,7 @@ public class ModStatusBar {
 
                     mScreenWidth = (float) res.getDisplayMetrics().widthPixels;
                     mMinBrightness = res.getInteger(res.getIdentifier(
-                            "config_screenBrightnessDim", "integer", "android"));
+                            "config_screenBrightnessSettingMinimum", "integer", "android"));
                     mPeekHeight = res.getDimensionPixelSize(res.getIdentifier(
                             "peek_height", "dimen", PACKAGE_NAME));
                     BRIGHTNESS_ON = XposedHelpers.getStaticIntField(powerManagerClass, "BRIGHTNESS_ON");


### PR DESCRIPTION
If Gravitybox was used to lower the Minimum Brightness this change wasn't reflected for the optional  Statusbar Brightness Control.
