### PR TITLE
Corregidos errores

### DIFF
--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -596,7 +596,7 @@
     <!-- Statusbar expand policy -->
     <string name="pref_statusbar_lock_policy_title">Política de bloqueo de la barra de estado</string>
     <string name="sbl_policy_default">Predeterminado</string>
-    <string name="sbl_policy_unlocked">Desbloqueada incluso con PIN/contraseña/patrón</string>
+    <string name="sbl_policy_unlocked">Bloqueada con PIN/contraseña/patrón</string>
     <string name="sbl_policy_unlocked_secured">Desbloqueado</string>
     <string name="sbl_policy_locked">Bloqueada</string>
 
@@ -1681,7 +1681,7 @@
     <string name="pref_heads_up_alpha_title">Nivel de transparencia</string>
     
     <!-- Charger unplugged sound -->
-    <string name="pref_charger_unplugged_sound_title">Sonido al desconectar cargados</string>
+    <string name="pref_charger_unplugged_sound_title">Sonido al desconectar cargador</string>
     
     <!-- Fake ID patch -->
     <string name="pref_patch_fake_id_title">Solucionar vulnerabilidad Fake ID</string>


### PR DESCRIPTION
Corregida líena 599 "Desbloqueada incluso con PIN/contraseña/patrón" lo correcto es "Bloqueada con PIN/contraseña/patrón"

Corregida línea 1684 "Sonido al desconectar cargados", cambiada la S del final por una R
