### PR TITLE
Utils: improve detection of GPE devices

### DIFF
--- a/src/com/ceco/kitkat/gravitybox/Utils.java
+++ b/src/com/ceco/kitkat/gravitybox/Utils.java
@@ -178,7 +178,7 @@ public class Utils {
 
         String productName = Build.PRODUCT.toLowerCase();
         mIsGpeDevice = Build.DEVICE.toLowerCase().contains("gpe") || productName.contains("google")
-                || productName.contains("ged");
+                || productName.contains("ged") || productName.contains("gpe");
         return mIsGpeDevice;
     }
 


### PR DESCRIPTION
Add "productName.contains("gpe")" to isGpeDevice() to detect other GPE devices such as the Moto G.
