### PR TITLE
Additional Moto MSIM updates

### DIFF
--- a/src/com/ceco/lollipop/gravitybox/PhoneWrapper.java
+++ b/src/com/ceco/lollipop/gravitybox/PhoneWrapper.java
@@ -220,6 +220,10 @@ public class PhoneWrapper {
                         "getDefault");
             mHasMsimSupport = (Boolean) XposedHelpers.callMethod(mtm, "isMultiSimEnabled") &&
                     (Integer) XposedHelpers.callMethod(mtm, "getPhoneCount") > 1;
+            if (DEBUG) log("isMultiSimEnabled: " +
+                    (Boolean) XposedHelpers.callMethod(mtm, "isMultiSimEnabled"));
+            if (DEBUG) log("getPhoneCount: " +
+                    (Integer) XposedHelpers.callMethod(mtm, "getPhoneCount"));
         } catch (Throwable t) {
             if (DEBUG) XposedBridge.log(t);
             mHasMsimSupport = false;

--- a/src/com/ceco/lollipop/gravitybox/StatusbarSignalCluster.java
+++ b/src/com/ceco/lollipop/gravitybox/StatusbarSignalCluster.java
@@ -272,25 +272,14 @@ public class StatusbarSignalCluster implements BroadcastSubReceiver, IconManager
 
     protected void createHooks() {
         try {
-            if (!Utils.isMotoXtDevice()) {
-                XposedHelpers.findAndHookMethod(mView.getClass(), "apply", new XC_MethodHook() {
-                    @Override
-                    protected void afterHookedMethod(MethodHookParam param) throws Throwable {
-                        if (mView != param.thisObject) return;
+            XposedHelpers.findAndHookMethod(mView.getClass(), "apply", new XC_MethodHook() {
+                @Override
+                protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+                    if (mView != param.thisObject) return;
 
-                        apply();
-                    }
-                });
-            } else {
-                XposedHelpers.findAndHookMethod(mView.getClass(), "apply", int.class, new XC_MethodHook() {
-                    @Override
-                    protected void afterHookedMethod(MethodHookParam param) throws Throwable {
-                        if (mView != param.thisObject) return;
-
-                        apply();
-                    }
-                });
-            }
+                    apply();
+                }
+            });
         } catch (Throwable t) {
             log("Error hooking apply() method: " + t.getMessage());
         }
@@ -394,11 +383,7 @@ public class StatusbarSignalCluster implements BroadcastSubReceiver, IconManager
     protected void update() {
         if (mView != null) {
             try {
-                if (!Utils.isMotoXtDevice()) {
-                    XposedHelpers.callMethod(mView, "apply");
-                } else {
-                    XposedHelpers.callMethod(mView, "apply", 0);
-                }
+                XposedHelpers.callMethod(mView, "apply");
             } catch (Throwable t) {
                 logAndMute("invokeApply", t);
             }

--- a/src/com/ceco/lollipop/gravitybox/StatusbarSignalCluster.java
+++ b/src/com/ceco/lollipop/gravitybox/StatusbarSignalCluster.java
@@ -222,6 +222,8 @@ public class StatusbarSignalCluster implements BroadcastSubReceiver, IconManager
         sPrefs = prefs;
         if (PhoneWrapper.hasMsimSupport()) {
             return new StatusbarSignalClusterMsim(containerType, view);
+        } else if (Utils.isMotoXtDevice()) {
+            return new StatusbarSignalClusterMsim(containerType, view);
         } else if (Utils.isMtkDevice()) {
             return new StatusbarSignalClusterMtk(containerType, view);
         } else {

--- a/src/com/ceco/lollipop/gravitybox/StatusbarSignalClusterMsim.java
+++ b/src/com/ceco/lollipop/gravitybox/StatusbarSignalClusterMsim.java
@@ -247,7 +247,7 @@ public class StatusbarSignalClusterMsim extends StatusbarSignalCluster {
                     mDataActivityEnabled && mMobileActivity != null) {
             if (mMobileActivity != null) {
                 for (int i=0; i < mMobileActivity.length; i++) {
-                    mMobileActivity[i].updateDataActivityColor();
+                    if (mMobileActivity[i] != null) mMobileActivity[i].updateDataActivityColor();
                 }
             }
         }


### PR DESCRIPTION
- Add debug output to hasMsimSupport()
- Revert previous fix for Moto XT devices and StatusbarSignalCluster
- Use StatusbarSignalClusterMsim for Moto XT devices instead
- Try and make StatusbarSignalClusterMsim more generic with regards to number of SIM slots or array positions.  This makes it less scary to use for devices with only one SIM card (like some Moto XT devices...)

Let me know what criticisms I should correct.  Also anything in particular I should test with moving Moto XT to StatusbarSignalClusterMsim?  Data activity indicators work.  I would also of course like to make sure it didn't cause any regressions on your dual SIM Moto G.
