### PR TITLE
Moto MSIM and XT cleanup

### DIFF
--- a/src/com/ceco/lollipop/gravitybox/GravityBoxSettings.java
+++ b/src/com/ceco/lollipop/gravitybox/GravityBoxSettings.java
@@ -1606,9 +1606,6 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
                 if (!sSystemProperties.hasMsimSupport) {
                     mPrefCatStatusbarColors.removePreference(mPrefSbIconColorSecondary);
                 }
-                if (Utils.isMotoXtDevice()) {
-                    mPrefCatStatusbarColors.removePreference(mPrefSbSignalColorMode);
-                }
                 mPrefCatSignalCluster.removePreference(mPrefSbDaColorSecondary);
                 //mPrefCatLsOther.removePreference(mPrefLockscreenCarrier2Text);
             } else {

--- a/src/com/ceco/lollipop/gravitybox/ModPowerMenu.java
+++ b/src/com/ceco/lollipop/gravitybox/ModPowerMenu.java
@@ -497,6 +497,8 @@ public class ModPowerMenu {
                 return true;
             } else if (methodName.equals("showConditional")) {
                 return true;
+            } else if (methodName.equals("getLabelForAccessibility")) {
+                return null;
             } else {
                 log("RebootAction: Unhandled invocation method: " + methodName);
                 return null;
@@ -589,6 +591,8 @@ public class ModPowerMenu {
                 return true;
             } else if (methodName.equals("showConditional")) {
                 return true;
+            } else if (methodName.equals("getLabelForAccessibility")) {
+                return null;
             } else {
                 log("ExpandedDesktopAction: Unhandled invocation method: " + methodName);
                 return null;
@@ -642,6 +646,8 @@ public class ModPowerMenu {
                 return true;
             } else if (methodName.equals("showConditional")) {
                 return true;
+            } else if (methodName.equals("getLabelForAccessibility")) {
+                return null;
             } else {
                 log("ScreenshotAction: Unhandled invocation method: " + methodName);
                 return null;
@@ -705,6 +711,8 @@ public class ModPowerMenu {
                 return true;
             } else if (methodName.equals("showConditional")) {
                 return true;
+            } else if (methodName.equals("getLabelForAccessibility")) {
+                return null;
             } else {
                 log("ScreenrecordAction: Unhandled invocation method: " + methodName);
                 return null;

--- a/src/com/ceco/lollipop/gravitybox/StatusbarSignalClusterMsim.java
+++ b/src/com/ceco/lollipop/gravitybox/StatusbarSignalClusterMsim.java
@@ -84,7 +84,7 @@ public class StatusbarSignalClusterMsim extends StatusbarSignalCluster {
                             }
 
                             if (mMobileActivity == null) {
-                                mMobileActivity = new SignalActivity[2];
+                                mMobileActivity = new SignalActivity[PhoneWrapper.getPhoneCount()];
                             }
 
                             for (int i=0; i < PhoneWrapper.getPhoneCount(); i++) {
@@ -261,10 +261,8 @@ public class StatusbarSignalClusterMsim extends StatusbarSignalCluster {
 
         if ((flags & StatusBarIconManager.FLAG_DATA_ACTIVITY_COLOR_CHANGED) != 0 &&
                     mDataActivityEnabled && mMobileActivity != null) {
-            if (mMobileActivity != null) {
-                for (int i=0; i < mMobileActivity.length; i++) {
-                    if (mMobileActivity[i] != null) mMobileActivity[i].updateDataActivityColor();
-                }
+            for (int i=0; i < mMobileActivity.length; i++) {
+                if (mMobileActivity[i] != null) mMobileActivity[i].updateDataActivityColor();
             }
         }
     }

--- a/src/com/ceco/lollipop/gravitybox/managers/StatusBarIconManager.java
+++ b/src/com/ceco/lollipop/gravitybox/managers/StatusBarIconManager.java
@@ -237,9 +237,6 @@ public class StatusBarIconManager implements BroadcastSubReceiver {
 
     public void setSignalIconMode(int mode) {
         // always force stock icon mode for Moto devices
-        if (Utils.isMotoXtDevice()) {
-            mode = SI_MODE_STOCK;
-        }
         if (mColorInfo.signalIconMode != mode) {
             mColorInfo.signalIconMode = mode;
             clearCache();


### PR DESCRIPTION
- Minor cleanup to SignalCluster MSIM
- Remove a couple of XT device checks that don't seem necessary on LP
  - Switching to JB icons seems to work fine
  - Toggling signal icon coloring seems to work fine

Anything in particular I should test with either of those?  Maybe you remember why they were added in a previous version.
