### PR TITLE
Additional reflection cleanups

### DIFF
--- a/src/com/ceco/lollipop/gravitybox/ModHwKeys.java
+++ b/src/com/ceco/lollipop/gravitybox/ModHwKeys.java
@@ -15,6 +15,8 @@
 
 package com.ceco.lollipop.gravitybox;
 
+import java.lang.reflect.Method;
+
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -147,6 +149,8 @@ public class ModHwKeys {
     private static long[] mVkVibePattern;
     private static long[] mVkVibePatternDefault;
     private static String[] mHeadsetUri = new String[2]; // index 0 = unplugged, index 1 = plugged 
+    private static Method mLaunchAssistAction = null;
+    private static Method mLaunchAssistLongPressAction = null;
 
     private static List<String> mKillIgnoreList = new ArrayList<String>(Arrays.asList(
             "com.android.systemui",
@@ -378,6 +382,23 @@ public class ModHwKeys {
         }
     };
 
+    private static void initReflections(Class<?> classPhoneWindowManager) {
+        try {
+            if (mLaunchAssistAction == null) {
+                mLaunchAssistAction = classPhoneWindowManager.getDeclaredMethod(
+                        "launchAssistAction");
+                mLaunchAssistAction.setAccessible(true);
+            }
+            if (mLaunchAssistLongPressAction == null) {
+                mLaunchAssistLongPressAction = classPhoneWindowManager.getDeclaredMethod(
+                        "launchAssistLongPressAction");
+                mLaunchAssistLongPressAction.setAccessible(true);
+            }
+        } catch (Throwable t) {
+            XposedBridge.log(t);
+        }
+    }
+
     public static void initZygote(final XSharedPreferences prefs) {
         try {
             mPrefs = prefs;
@@ -476,6 +497,7 @@ public class ModHwKeys {
             mHeadsetUri[1] = prefs.getString(GravityBoxSettings.PREF_KEY_HEADSET_ACTION_PLUG, null);
 
             final Class<?> classPhoneWindowManager = XposedHelpers.findClass(CLASS_PHONE_WINDOW_MANAGER, null);
+            initReflections(classPhoneWindowManager);
 
             XposedHelpers.findAndHookMethod(classPhoneWindowManager, "init",
                 Context.class, CLASS_IWINDOW_MANAGER, CLASS_WINDOW_MANAGER_FUNCS, phoneWindowManagerInitHook);
@@ -1144,7 +1166,7 @@ public class ModHwKeys {
 
     private static void launchSearchActivity() {
         try {
-            XposedHelpers.callMethod(mPhoneWindowManager, "launchAssistAction");
+            mLaunchAssistAction.invoke(mPhoneWindowManager);
         } catch (Exception e) {
             XposedBridge.log(e);
         }
@@ -1152,7 +1174,7 @@ public class ModHwKeys {
 
     private static void launchVoiceSearchActivity() {
         try {
-            XposedHelpers.callMethod(mPhoneWindowManager, "launchAssistLongPressAction");
+            mLaunchAssistLongPressAction.invoke(mPhoneWindowManager);
         } catch (Exception e) {
             XposedBridge.log(e);
         }


### PR DESCRIPTION
Cleaned up our manual reflections based on the find you made:
- ModExpandedDesktop
  - Split initialization to a separate method to reduce clutter in initZygote.
  - Removed manual reflection for getStatusBarService and added one for requestTransientBars
  - Alphabetized them
- ModHwKeys
  - Added manual reflections for the only two methods which seem to be declared private.  They were causing soft reboots to my phone too since I hadn't picked a default for those two actions.
