### PR TITLE
Dialer: adjust unknown caller photo for Dialer 2.3

### DIFF
--- a/src/com/ceco/marshmallow/gravitybox/ModDialer.java
+++ b/src/com/ceco/marshmallow/gravitybox/ModDialer.java
@@ -239,7 +239,7 @@ public class ModDialer {
 
                     refreshPhonePrefs();
                     if (prefs.getBoolean(GravityBoxSettings.PREF_KEY_CALLER_FULLSCREEN_PHOTO, false)) { 
-                    final View v = ((Fragment) param.thisObject).getView(); 
+                    final View v = ((Fragment)param.thisObject).getView();
                         v.setBackgroundColor(0);
                         if (Utils.isMtkDevice()) {
                             final View gpView = (View) XposedHelpers.getObjectField(param.thisObject, "mGlowpad");
@@ -256,39 +256,75 @@ public class ModDialer {
         try {
             final Class<?> classCallCardFragment = XposedHelpers.findClass(CLASS_CALL_CARD_FRAGMENT, classLoader);
 
-            XposedHelpers.findAndHookMethod(classCallCardFragment, "setDrawableToImageView",
-                    ImageView.class, Drawable.class, new XC_MethodHook() {
-                @Override
-                protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
-                    if (!prefs.getBoolean(
-                            GravityBoxSettings.PREF_KEY_CALLER_UNKNOWN_PHOTO_ENABLE, false)) return;
+            try {
+                XposedHelpers.findAndHookMethod(classCallCardFragment, "setDrawableToImageView",
+                        ImageView.class, Drawable.class, new XC_MethodHook() {
+                    @Override
+                    protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                        if (!prefs.getBoolean(
+                                GravityBoxSettings.PREF_KEY_CALLER_UNKNOWN_PHOTO_ENABLE, false)) return;
 
-                    boolean shouldShowUnknownPhoto = param.args[1] == null;
-                    if (param.args[1] != null) {
-                        final Fragment frag = (Fragment) param.thisObject;
-                        final Resources res = frag.getResources();
-                        String resName = "img_no_image_automirrored";
-                        Drawable picUnknown = res.getDrawable(res.getIdentifier(resName, "drawable",
-                                        res.getResourcePackageName(frag.getId())), null);
-                        shouldShowUnknownPhoto = ((Drawable)param.args[1]).getConstantState().equals(
-                                                    picUnknown.getConstantState());
-                    }
+                        boolean shouldShowUnknownPhoto = param.args[1] == null;
+                        if (param.args[1] != null) {
+                            final Fragment frag = (Fragment) param.thisObject;
+                            final Resources res = frag.getResources();
+                            String resName = "img_no_image_automirrored";
+                            Drawable picUnknown = res.getDrawable(res.getIdentifier(resName, "drawable",
+                                            res.getResourcePackageName(frag.getId())), null);
+                            shouldShowUnknownPhoto = ((Drawable)param.args[1]).getConstantState().equals(
+                                                        picUnknown.getConstantState());
+                        }
 
-                    if (shouldShowUnknownPhoto) {
-                        final ImageView iv = (ImageView) param.args[0];
-                        final Context context = iv.getContext();
-                        final String path = Utils.getGbContext(context).getFilesDir() + "/caller_photo";
-                        File f = new File(path);
-                        if (f.exists() && f.canRead()) {
-                            Bitmap b = BitmapFactory.decodeFile(path);
-                            if (b != null) {
-                                param.args[1] = new BitmapDrawable(context.getResources(), b);
-                                if (DEBUG) log("Unknow caller photo set");
+                        if (shouldShowUnknownPhoto) {
+                            final ImageView iv = (ImageView) param.args[0];
+                            final Context context = iv.getContext();
+                            final String path = Utils.getGbContext(context).getFilesDir() + "/caller_photo";
+                            File f = new File(path);
+                            if (f.exists() && f.canRead()) {
+                                Bitmap b = BitmapFactory.decodeFile(path);
+                                if (b != null) {
+                                    param.args[1] = new BitmapDrawable(context.getResources(), b);
+                                    if (DEBUG) log("Unknow caller photo set");
+                                }
                             }
                         }
                     }
-                }
-            });
+                });
+            } catch (Throwable t) {
+                XposedHelpers.findAndHookMethod(classCallCardFragment, "setDrawableToImageViews",
+                        Drawable.class, new XC_MethodHook() {
+                    @Override
+                    protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                        if (!prefs.getBoolean(
+                                GravityBoxSettings.PREF_KEY_CALLER_UNKNOWN_PHOTO_ENABLE, false)) return;
+
+                        boolean shouldShowUnknownPhoto = param.args[0] == null;
+                        if (param.args[0] != null) {
+                            final Fragment frag = (Fragment) param.thisObject;
+                            final Resources res = frag.getResources();
+                            String resName = "img_no_image_automirrored";
+                            Drawable picUnknown = res.getDrawable(res.getIdentifier(resName, "drawable",
+                                            res.getResourcePackageName(frag.getId())), null);
+                            shouldShowUnknownPhoto = ((Drawable)param.args[0]).getConstantState().equals(
+                                                        picUnknown.getConstantState());
+                        }
+
+                        if (shouldShowUnknownPhoto) {
+                            final View v = ((Fragment) param.thisObject).getView();
+                            final Context context = v.getContext();
+                            final String path = Utils.getGbContext(context).getFilesDir() + "/caller_photo";
+                            File f = new File(path);
+                            if (f.exists() && f.canRead()) {
+                                Bitmap b = BitmapFactory.decodeFile(path);
+                                if (b != null) {
+                                    param.args[0] = new BitmapDrawable(context.getResources(), b);
+                                    if (DEBUG) log("Unknow caller photo set");
+                                }
+                            }
+                        }
+                    }
+                });
+            }
         } catch (Throwable t) {
             XposedBridge.log(t);
         }


### PR DESCRIPTION
setDrawableToImageView() was renamed to setDrawableToImageViews() and has only one parameter (the drawable).  We use the Fragment object to get the view and context instead of the old ImageView parameter.  Otherwise its more or less the same.
