### PR TITLE
Volume pannel bug

### DIFF
--- a/src/com/ceco/kitkat/gravitybox/ModVolumePanel.java
+++ b/src/com/ceco/kitkat/gravitybox/ModVolumePanel.java
@@ -393,7 +393,7 @@ public class ModVolumePanel {
     }
 
     private static void updateVolumePanelMode() {
-        if (mVolumePanel == null) return;
+        if ((mVolumePanel == null) || (mExpandable == false)) return;
 
         try {
             View mMoreButton = (View) XposedHelpers.getObjectField(mVolumePanel, "mMoreButton");


### PR DESCRIPTION
The volume panel is hooked even if the feature is not enabled, it should not happen. 
This result in overwriting the Original CM Settings
