### PR TITLE
Utils: Add support for Brazilian Moto Gs

### DIFF
--- a/src/com/ceco/lollipop/gravitybox/Utils.java
+++ b/src/com/ceco/lollipop/gravitybox/Utils.java
@@ -189,7 +189,7 @@ public class Utils {
     public static boolean isFalconAsiaDs() {
         if (mIsFalconAsiaDs != null) return mIsFalconAsiaDs;
 
-        mIsFalconAsiaDs = isMotoXtDevice() && "falcon_asia_ds".equals(Build.PRODUCT);
+        mIsFalconAsiaDs = isMotoXtDevice() && (Build.PRODUCT.equalsIgnoreCase("falcon_asia_ds") || Build.PRODUCT.equalsIgnoreCase("falcon_retbr_ds"));
         return mIsFalconAsiaDs;
     }
 


### PR DESCRIPTION
There's very little difference between the Asian and Brazilian firmwares for the Moto G1, so why not support both?
