### PR TITLE
Fix navbar dimentions does not load on startup

### DIFF
--- a/src/com/ceco/lollipop/gravitybox/ModExpandedDesktop.java
+++ b/src/com/ceco/lollipop/gravitybox/ModExpandedDesktop.java
@@ -213,20 +213,36 @@ public class ModExpandedDesktop {
                         = navigationBarHeightForRotation[upsideDownRotation]
                         = navigationBarHeightForRotation[landscapeRotation]
                         = navigationBarHeightForRotation[seascapeRotation] = 0;
-            } else if (mNavbarDimensions != null) {
+            } else {
+                final int resWidthId = mContext.getResources().getIdentifier(
+                        "navigation_bar_width", "dimen", "android");
+                final int resHeightId = mContext.getResources().getIdentifier(
+                        "navigation_bar_height", "dimen", "android");
+                final int resHeightLandscapeId = mContext.getResources().getIdentifier(
+                        "navigation_bar_height_landscape", "dimen", "android");
+
+
                 navigationBarHeightForRotation[portraitRotation] =
                 navigationBarHeightForRotation[upsideDownRotation] =
-                        mNavbarDimensions.hPort;
+                    (int) (mContext.getResources().getDimensionPixelSize(resHeightId)
+                    * mNavbarHeightScaleFactor);
+
                 navigationBarHeightForRotation[landscapeRotation] =
                 navigationBarHeightForRotation[seascapeRotation] =
-                        mNavbarDimensions.hLand;
+                    (int) (mContext.getResources().getDimensionPixelSize(resHeightLandscapeId)
+                    * mNavbarHeightLandscapeScaleFactor);
+
 
                 navigationBarWidthForRotation[portraitRotation] =
                 navigationBarWidthForRotation[upsideDownRotation] =
                 navigationBarWidthForRotation[landscapeRotation] =
                 navigationBarWidthForRotation[seascapeRotation] =
-                        mNavbarDimensions.wPort;
+                    (int) (mContext.getResources().getDimensionPixelSize(resWidthId)
+                    * mNavbarWidthScaleFactor);
+
             }
+            XposedHelpers.setObjectField(mPhoneWindowManager, "mNavigationBarWidthForRotation", navigationBarWidthForRotation);
+            XposedHelpers.setObjectField(mPhoneWindowManager, "mNavigationBarHeightForRotation", navigationBarHeightForRotation);
 
             XposedHelpers.callMethod(mPhoneWindowManager, "updateRotation", false);
         } catch (Throwable t) {


### PR DESCRIPTION
Downgrade to 5.1.1.rev2 because navbar dimensions does not load at startup with new version
Tested System : Android TV - 5.1.1 
Device : MXIII N200C
Navbar default system config : Auto hide 
