### PR TITLE
Fix broken signal cluster tweaks on Motorola stock ROMs

### DIFF
--- a/src/com/ceco/marshmallow/gravitybox/StatusbarSignalCluster.java
+++ b/src/com/ceco/marshmallow/gravitybox/StatusbarSignalCluster.java
@@ -536,13 +536,7 @@ public class StatusbarSignalCluster implements BroadcastSubReceiver, IconManager
 
     protected void setNetworkController(Object networkController) {
         final ClassLoader classLoader = mView.getClass().getClassLoader();
-        final Class<?> networkCtrlCbClass = Utils.isMotoXtDevice() ?
-                XposedHelpers.findClass(
-                "com.android.systemui.statusbar.policy.MotorolaNetworkController.SignalCallback", 
-                classLoader) :
-                XposedHelpers.findClass(
-                "com.android.systemui.statusbar.policy.NetworkController.SignalCallback", 
-                classLoader);
+        final Class<?> networkCtrlCbClass = XposedHelpers.findClass("com.android.systemui.statusbar.policy.NetworkController.SignalCallback", classLoader);
         mNetworkControllerCallback = Proxy.newProxyInstance(classLoader, 
                 new Class<?>[] { networkCtrlCbClass }, new NetworkControllerCallback());
             XposedHelpers.callMethod(networkController, "addSignalCallback",

--- a/src/com/ceco/marshmallow/gravitybox/StatusbarSignalCluster.java
+++ b/src/com/ceco/marshmallow/gravitybox/StatusbarSignalCluster.java
@@ -366,7 +366,7 @@ public class StatusbarSignalCluster implements BroadcastSubReceiver, IconManager
                             Constructor<?> c = hGroup.getClass().getConstructor(
                                     String.class, int[][].class, int[][].class, int[].class,
                                     int.class, int.class, int.class, int.class,
-                                    int.class, int.class, int.class, boolean.class, int[].class,
+                                    int.class, int.class, int.class, boolean.class, int.class,
                                     int[][].class, int[][].class, boolean.class, boolean.class,
                                     int[].class, int[].class, int[].class, int[].class,
                                     int[].class, int[].class, int[].class, int[].class,
@@ -385,7 +385,7 @@ public class StatusbarSignalCluster implements BroadcastSubReceiver, IconManager
                                     XposedHelpers.getIntField(hGroup, "mDataContentDescription"),
                                     sSbHpResId,
                                     XposedHelpers.getBooleanField(hGroup, "mIsWide"),
-                                    new int[] { sQsHpResId, sQsHpResId },
+                                    sQsHpResId,
                                     XposedHelpers.getObjectField(hGroup, "mMotoSBActivityAOSPLookup"),
                                     XposedHelpers.getObjectField(hGroup, "mMotoQSActivityAOSPLookup"),
                                     XposedHelpers.getBooleanField(hGroup, "mIsMotoUI"),


### PR DESCRIPTION
- The class "MotorolaNetworkController" doesn't exist at all. Motorola devices use the same NetworkController class as AOSP devices do. The difference is that they use a "MotorolaNetworkControllerImpl" class.
