### PR TITLE
Add Custom Sound for Low Battery Warning

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -12,14 +12,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Modifications copyright (C) 2016 Aire-One (Aire-One@xda ; Aire-One@github)
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.ceco.gm2.gravitybox"
     android:versionCode="132"
-    android:versionName="3.7.1" >
+    android:versionName="3.7.0" >
 
     <uses-sdk
         android:minSdkVersion="16"

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -12,12 +12,14 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modifications copyright (C) 2016 Aire-One (Aire-One@xda ; Aire-One@github)
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.ceco.gm2.gravitybox"
     android:versionCode="132"
-    android:versionName="3.7.0" >
+    android:versionName="3.7.1" >
 
     <uses-sdk
         android:minSdkVersion="16"

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modifications copyright (C) 2016 Aire-One (Aire-One@xda ; Aire-One@github)
 -->
 
 <resources>
@@ -69,6 +71,7 @@
         <item>@string/low_battery_warning_popup</item>
         <item>@string/low_battery_warning_sound</item>
         <item>@string/low_battery_warning_off</item>
+        <item>@string/low_battery_warning_customsound</item>
     </string-array>
 
     <string-array name="low_battery_warning_policy_values" translatable="false">
@@ -76,6 +79,7 @@
         <item>1</item>
         <item>2</item>
         <item>0</item>
+        <item>6</item> <!-- "6" instead of simply "4" to match logical & from low battery sound test on "playLowBatterySound" 's Hook -->
     </string-array>
 
     <string-array name="signal_icon_autohide_entries"  translatable="false">

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Modifications copyright (C) 2016 Aire-One (Aire-One@xda ; Aire-One@github)
 -->
 
 <resources>
@@ -71,7 +69,6 @@
         <item>@string/low_battery_warning_popup</item>
         <item>@string/low_battery_warning_sound</item>
         <item>@string/low_battery_warning_off</item>
-        <item>@string/low_battery_warning_customsound</item>
     </string-array>
 
     <string-array name="low_battery_warning_policy_values" translatable="false">
@@ -79,7 +76,6 @@
         <item>1</item>
         <item>2</item>
         <item>0</item>
-        <item>6</item> <!-- "6" instead of simply "4" to match logical & from low battery sound test on "playLowBatterySound" 's Hook -->
     </string-array>
 
     <string-array name="signal_icon_autohide_entries"  translatable="false">

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Modifications copyright (C) 2016 Aire-One (Aire-One@xda ; Aire-One@github)
 -->
 
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
@@ -36,9 +34,6 @@
     <string name="low_battery_warning_popup">Pop-up only</string>
     <string name="low_battery_warning_sound">Sound only</string>
     <string name="low_battery_warning_off">Off</string>
-    <string name="low_battery_warning_customsound">Custom sound (sound only)</string>
-    <string name="low_battery_select_customsound_title">Low battery Custom Sound</string>
-    <string name="low_battery_select_customsound_summary">Needs to select Custom Sound for Low battery warning</string>
 
     <string name="reboot_required">Change will be applied after reboot</string>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modifications copyright (C) 2016 Aire-One (Aire-One@xda ; Aire-One@github)
 -->
 
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
@@ -34,6 +36,9 @@
     <string name="low_battery_warning_popup">Pop-up only</string>
     <string name="low_battery_warning_sound">Sound only</string>
     <string name="low_battery_warning_off">Off</string>
+    <string name="low_battery_warning_customsound">Custom sound (sound only)</string>
+    <string name="low_battery_select_customsound_title">Low battery Custom Sound</string>
+    <string name="low_battery_select_customsound_summary">Needs to select Custom Sound for Low battery warning</string>
 
     <string name="reboot_required">Change will be applied after reboot</string>
 

--- a/res/xml/gravitybox.xml
+++ b/res/xml/gravitybox.xml
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modifications copyright (C) 2016 Aire-One (Aire-One@xda ; Aire-One@github)
 -->
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
@@ -1597,6 +1599,15 @@
                 android:entries="@array/low_battery_warning_policy_entries"
                 android:entryValues="@array/low_battery_warning_policy_values"
                 android:defaultValue="3" />
+
+            <RingtonePreference
+                android:key="pref_battery_warning_customsound"
+                android:title="@string/low_battery_select_customsound_title"
+                android:summary="@string/low_battery_select_customsound_summary"
+                android:ringtoneType="notification"
+                android:showDefault="true"
+                android:showSilent="true"
+                android:defaultValue="" />
 
             <RingtonePreference 
                 android:key="pref_battery_charged_sound2"

--- a/res/xml/gravitybox.xml
+++ b/res/xml/gravitybox.xml
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Modifications copyright (C) 2016 Aire-One (Aire-One@xda ; Aire-One@github)
 -->
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
@@ -1599,15 +1597,6 @@
                 android:entries="@array/low_battery_warning_policy_entries"
                 android:entryValues="@array/low_battery_warning_policy_values"
                 android:defaultValue="3" />
-
-            <RingtonePreference
-                android:key="pref_battery_warning_customsound"
-                android:title="@string/low_battery_select_customsound_title"
-                android:summary="@string/low_battery_select_customsound_summary"
-                android:ringtoneType="notification"
-                android:showDefault="true"
-                android:showSilent="true"
-                android:defaultValue="" />
 
             <RingtonePreference 
                 android:key="pref_battery_charged_sound2"

--- a/src/com/ceco/gm2/gravitybox/GravityBoxSettings.java
+++ b/src/com/ceco/gm2/gravitybox/GravityBoxSettings.java
@@ -11,6 +11,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modifications copyright (C) 2016 Aire-One (Aire-One@xda ; Aire-One@github)
  */
 
 package com.ceco.gm2.gravitybox;
@@ -125,6 +127,8 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
     public static final String PREF_KEY_LOW_BATTERY_WARNING_POLICY = "pref_low_battery_warning_policy";
     public static final int BATTERY_WARNING_POPUP = 1;
     public static final int BATTERY_WARNING_SOUND = 2;
+    public static final int BATTERY_WARNING_CUSTOMSOUND = 4; // 4 for checkes only if the first bit matches but should be 6 to check the whole bits
+    public static final String PREF_KEY_LOW_BATTERY_WARNING_CUSTOMSOUND = "pref_battery_warning_customsound";
     public static final String PREF_KEY_BATTERY_CHARGED_SOUND = "pref_battery_charged_sound2";
     public static final String PREF_KEY_CHARGER_PLUGGED_SOUND = "pref_charger_plugged_sound2";
     public static final String PREF_KEY_CHARGER_UNPLUGGED_SOUND = "pref_charger_unplugged_sound";
@@ -915,7 +919,8 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
     private static final List<String> ringToneKeys = new ArrayList<String>(Arrays.asList(
             PREF_KEY_BATTERY_CHARGED_SOUND,
             PREF_KEY_CHARGER_PLUGGED_SOUND,
-            PREF_KEY_CHARGER_UNPLUGGED_SOUND
+            PREF_KEY_CHARGER_UNPLUGGED_SOUND,
+            PREF_KEY_LOW_BATTERY_WARNING_CUSTOMSOUND
     ));
 
     private static final List<String> lockscreenKeys = new ArrayList<String>(Arrays.asList(
@@ -1100,6 +1105,7 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
         private ListPreference mPrefBatteryPercentStyle;
         private ListPreference mPrefBatteryPercentCharging;
         private ListPreference mLowBatteryWarning;
+        private RingtonePreference mPrefLowBatteryWarningCustomsound;
         private MultiSelectListPreference mSignalIconAutohide;
         private SharedPreferences mPrefs;
         private AlertDialog mDialog;
@@ -1329,6 +1335,7 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
             mPrefBatteryPercentStyle = (ListPreference) findPreference(PREF_KEY_BATTERY_PERCENT_TEXT_STYLE);
             mPrefBatteryPercentCharging = (ListPreference) findPreference(PREF_KEY_BATTERY_PERCENT_TEXT_CHARGING);
             mLowBatteryWarning = (ListPreference) findPreference(PREF_KEY_LOW_BATTERY_WARNING_POLICY);
+            mPrefLowBatteryWarningCustomsound = (RingtonePreference) findPreference(PREF_KEY_LOW_BATTERY_WARNING_CUSTOMSOUND);
             mSignalIconAutohide = (MultiSelectListPreference) findPreference(PREF_KEY_SIGNAL_ICON_AUTOHIDE);
             mQuickSettings = (MultiSelectListPreference) findPreference(PREF_KEY_QUICK_SETTINGS);
             mStatusbarBgColor = (ColorPickerPreference) findPreference(PREF_KEY_STATUSBAR_BGCOLOR);
@@ -2052,6 +2059,12 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
 
             if (key == null || key.equals(PREF_KEY_LOW_BATTERY_WARNING_POLICY)) {
                 mLowBatteryWarning.setSummary(mLowBatteryWarning.getEntry());
+
+                final int val = Integer.parseInt(mLowBatteryWarning.getValue());
+                if(val == 6)
+                    mPrefLowBatteryWarningCustomsound.setEnabled(true);
+                else
+                    mPrefLowBatteryWarningCustomsound.setEnabled(false);
             }
 
             if (key == null || key.equals(PREF_KEY_SIGNAL_ICON_AUTOHIDE)) {
@@ -3217,6 +3230,11 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
                 intent.putExtra(EXTRA_BATTERY_SOUND_TYPE, BatteryInfoManager.SOUND_UNPLUGGED);
                 intent.putExtra(EXTRA_BATTERY_SOUND_URI,
                         prefs.getString(PREF_KEY_CHARGER_UNPLUGGED_SOUND, ""));
+            } else if (key.equals(PREF_KEY_LOW_BATTERY_WARNING_CUSTOMSOUND)) {
+                intent.setAction(ACTION_PREF_BATTERY_SOUND_CHANGED);
+                intent.putExtra(EXTRA_BATTERY_SOUND_TYPE, BatteryInfoManager.SOUND_LOWBATTERY);
+                intent.putExtra(EXTRA_BATTERY_SOUND_URI,
+                        prefs.getString(PREF_KEY_LOW_BATTERY_WARNING_CUSTOMSOUND, ""));
             } else if (key.equals(PREF_KEY_TRANS_VERIFICATION)) {
                 String transId = prefs.getString(key, null);
                 if (transId != null && !transId.trim().isEmpty()) {

--- a/src/com/ceco/gm2/gravitybox/GravityBoxSettings.java
+++ b/src/com/ceco/gm2/gravitybox/GravityBoxSettings.java
@@ -11,8 +11,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Modifications copyright (C) 2016 Aire-One (Aire-One@xda ; Aire-One@github)
  */
 
 package com.ceco.gm2.gravitybox;
@@ -127,8 +125,6 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
     public static final String PREF_KEY_LOW_BATTERY_WARNING_POLICY = "pref_low_battery_warning_policy";
     public static final int BATTERY_WARNING_POPUP = 1;
     public static final int BATTERY_WARNING_SOUND = 2;
-    public static final int BATTERY_WARNING_CUSTOMSOUND = 4; // 4 for checkes only if the first bit matches but should be 6 to check the whole bits
-    public static final String PREF_KEY_LOW_BATTERY_WARNING_CUSTOMSOUND = "pref_battery_warning_customsound";
     public static final String PREF_KEY_BATTERY_CHARGED_SOUND = "pref_battery_charged_sound2";
     public static final String PREF_KEY_CHARGER_PLUGGED_SOUND = "pref_charger_plugged_sound2";
     public static final String PREF_KEY_CHARGER_UNPLUGGED_SOUND = "pref_charger_unplugged_sound";
@@ -919,8 +915,7 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
     private static final List<String> ringToneKeys = new ArrayList<String>(Arrays.asList(
             PREF_KEY_BATTERY_CHARGED_SOUND,
             PREF_KEY_CHARGER_PLUGGED_SOUND,
-            PREF_KEY_CHARGER_UNPLUGGED_SOUND,
-            PREF_KEY_LOW_BATTERY_WARNING_CUSTOMSOUND
+            PREF_KEY_CHARGER_UNPLUGGED_SOUND
     ));
 
     private static final List<String> lockscreenKeys = new ArrayList<String>(Arrays.asList(
@@ -1105,7 +1100,6 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
         private ListPreference mPrefBatteryPercentStyle;
         private ListPreference mPrefBatteryPercentCharging;
         private ListPreference mLowBatteryWarning;
-        private RingtonePreference mPrefLowBatteryWarningCustomsound;
         private MultiSelectListPreference mSignalIconAutohide;
         private SharedPreferences mPrefs;
         private AlertDialog mDialog;
@@ -1335,7 +1329,6 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
             mPrefBatteryPercentStyle = (ListPreference) findPreference(PREF_KEY_BATTERY_PERCENT_TEXT_STYLE);
             mPrefBatteryPercentCharging = (ListPreference) findPreference(PREF_KEY_BATTERY_PERCENT_TEXT_CHARGING);
             mLowBatteryWarning = (ListPreference) findPreference(PREF_KEY_LOW_BATTERY_WARNING_POLICY);
-            mPrefLowBatteryWarningCustomsound = (RingtonePreference) findPreference(PREF_KEY_LOW_BATTERY_WARNING_CUSTOMSOUND);
             mSignalIconAutohide = (MultiSelectListPreference) findPreference(PREF_KEY_SIGNAL_ICON_AUTOHIDE);
             mQuickSettings = (MultiSelectListPreference) findPreference(PREF_KEY_QUICK_SETTINGS);
             mStatusbarBgColor = (ColorPickerPreference) findPreference(PREF_KEY_STATUSBAR_BGCOLOR);
@@ -2059,12 +2052,6 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
 
             if (key == null || key.equals(PREF_KEY_LOW_BATTERY_WARNING_POLICY)) {
                 mLowBatteryWarning.setSummary(mLowBatteryWarning.getEntry());
-
-                final int val = Integer.parseInt(mLowBatteryWarning.getValue());
-                if(val == 6)
-                    mPrefLowBatteryWarningCustomsound.setEnabled(true);
-                else
-                    mPrefLowBatteryWarningCustomsound.setEnabled(false);
             }
 
             if (key == null || key.equals(PREF_KEY_SIGNAL_ICON_AUTOHIDE)) {
@@ -3230,11 +3217,6 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
                 intent.putExtra(EXTRA_BATTERY_SOUND_TYPE, BatteryInfoManager.SOUND_UNPLUGGED);
                 intent.putExtra(EXTRA_BATTERY_SOUND_URI,
                         prefs.getString(PREF_KEY_CHARGER_UNPLUGGED_SOUND, ""));
-            } else if (key.equals(PREF_KEY_LOW_BATTERY_WARNING_CUSTOMSOUND)) {
-                intent.setAction(ACTION_PREF_BATTERY_SOUND_CHANGED);
-                intent.putExtra(EXTRA_BATTERY_SOUND_TYPE, BatteryInfoManager.SOUND_LOWBATTERY);
-                intent.putExtra(EXTRA_BATTERY_SOUND_URI,
-                        prefs.getString(PREF_KEY_LOW_BATTERY_WARNING_CUSTOMSOUND, ""));
             } else if (key.equals(PREF_KEY_TRANS_VERIFICATION)) {
                 String transId = prefs.getString(key, null);
                 if (transId != null && !transId.trim().isEmpty()) {

--- a/src/com/ceco/gm2/gravitybox/ModLowBatteryWarning.java
+++ b/src/com/ceco/gm2/gravitybox/ModLowBatteryWarning.java
@@ -11,26 +11,16 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Modifications copyright (C) 2016 Aire-One (Aire-One@xda ; Aire-One@github)
  */
 
 package com.ceco.gm2.gravitybox;
 
 import static de.robv.android.xposed.XposedHelpers.findAndHookMethod;
 import static de.robv.android.xposed.XposedHelpers.findClass;
-
-import android.app.Activity;
-import android.app.AndroidAppHelper;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.media.AudioManager;
-import android.media.Ringtone;
-import android.media.RingtoneManager;
-import android.net.Uri;
-import android.util.Log;
 
 import com.ceco.gm2.gravitybox.Utils.MethodState;
 
@@ -166,7 +156,7 @@ public class ModLowBatteryWarning {
         }
     }
 
-    static void init(final XSharedPreferences prefs, final ClassLoader classLoader) {
+    static void init(final XSharedPreferences prefs, ClassLoader classLoader) {
         try {
             if (DEBUG) log("init");
 
@@ -192,26 +182,10 @@ public class ModLowBatteryWarning {
                     final int batteryWarningPolicy = Integer.valueOf(
                             prefs.getString(GravityBoxSettings.PREF_KEY_LOW_BATTERY_WARNING_POLICY, "3"));
                     final boolean playSound = ((batteryWarningPolicy & GravityBoxSettings.BATTERY_WARNING_SOUND) != 0);
-                    final boolean customSound = ((batteryWarningPolicy & GravityBoxSettings.BATTERY_WARNING_CUSTOMSOUND) != 0);
 
-                    if (DEBUG) log("playLowBatterySound called; playSound = " + playSound + " ; customSound = " + customSound);
-
-                    if (customSound) {
-                        Uri sound = null;
-                        try {
-                            sound = Uri.parse(prefs.getString(GravityBoxSettings.PREF_KEY_LOW_BATTERY_WARNING_CUSTOMSOUND, ""));
-                            final Ringtone sfx = RingtoneManager.getRingtone(AndroidAppHelper.currentApplication(), sound); // any better way to get context ?
-                            if (sfx != null) {
-                                sfx.setStreamType(AudioManager.STREAM_NOTIFICATION);
-                                sfx.play();
-                            }
-                        } catch (Throwable t) {
-                            XposedBridge.log(t);
-                        }
-                        param.setResult(null);
-                    }
-
-                    if (!playSound || customSound)
+                    if (DEBUG) log("playLowBatterySound called; playSound = " + playSound);
+                    
+                    if (!playSound)
                         param.setResult(null);
                 }
 


### PR DESCRIPTION
Change Low Battery Warning Policy to add Custom Sound option
Add a ringtone preference entry for low battery (changable only if
custom sound is selected on low battery warging policy)
Change playLowBatterySound Hook to play custom sound
