### PR TITLE
Fix log spamming

### DIFF
--- a/src/com/ceco/marshmallow/gravitybox/ModDialer.java
+++ b/src/com/ceco/marshmallow/gravitybox/ModDialer.java
@@ -93,7 +93,7 @@ public class ModDialer {
                 }
             });
         } catch (Throwable t) {
-            XposedBridge.log(t);
+            //XposedBridge.log(t);
         }
 
         try {
@@ -138,7 +138,7 @@ public class ModDialer {
                         Drawable.class, unknownCallerHook);
             }
         } catch (Throwable t) {
-            XposedBridge.log(t);
+            //XposedBridge.log(t);
         }
 
         try {
@@ -163,7 +163,7 @@ public class ModDialer {
                 }
             });
         } catch (Throwable t) {
-            XposedBridge.log(t);
+            //XposedBridge.log(t);
         }
 
         try {
@@ -185,7 +185,7 @@ public class ModDialer {
                 }
             });
         } catch (Throwable t) {
-            XposedBridge.log(t);
+            //XposedBridge.log(t);
         }
     }
 }


### PR DESCRIPTION
It seems like that gravitybox can't find any of these methods any more. This normally is not a problem, but gravitybox is really spamming the Xposed log (can't find class...) making it totally unuseful! As a temporary solution I strongly suggest to remove the logging.