### PR TITLE
Samsung Nougat fixes

### DIFF
--- a/src/com/ceco/nougat/gravitybox/BatteryStyleController.java
+++ b/src/com/ceco/nougat/gravitybox/BatteryStyleController.java
@@ -240,13 +240,24 @@ public class BatteryStyleController implements BroadcastSubReceiver {
 
         if (mContainerType == ContainerType.KEYGUARD) {
             try {
-                XposedHelpers.findAndHookMethod(mContainer.getClass(), "onBatteryLevelChanged",
-                        int.class, boolean.class, boolean.class, new XC_MethodHook() {
-                    @Override
-                    protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+               if (Utils.isSamsungRom())
+               {
+                  XposedHelpers.findAndHookMethod(mContainer.getClass(), "onBatteryLevelChanged",
+                          int.class, boolean.class, boolean.class, int.class, int.class, int.class, int.class, boolean.class, new XC_MethodHook() {
+                     @Override
+                     protected void afterHookedMethod(MethodHookParam param) throws Throwable {
                         updateBatteryStyle();
-                    }
-                });
+                     }
+                  });
+               } else {
+                  XposedHelpers.findAndHookMethod(mContainer.getClass(), "onBatteryLevelChanged",
+                          int.class, boolean.class, boolean.class, new XC_MethodHook() {
+                     @Override
+                     protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+                        updateBatteryStyle();
+                     }
+                  });
+                 }
             } catch (Throwable t) {
                 XposedBridge.log(t);
             }

--- a/src/com/ceco/nougat/gravitybox/CmCircleBattery.java
+++ b/src/com/ceco/nougat/gravitybox/CmCircleBattery.java
@@ -330,7 +330,7 @@ public class CmCircleBattery extends ImageView implements IconManagerListener, B
     private void initSizeMeasureIconHeight() {
         final Resources res = getResources();
         mCircleSize = Math.round(TypedValue.applyDimension(
-                TypedValue.COMPLEX_UNIT_DIP, Utils.isSamsungRom() ? 15 : 17,
+                TypedValue.COMPLEX_UNIT_DIP, Utils.isSamsungRom() ? 14 : 17,
                 res.getDisplayMetrics()));
         mCircleSize = Math.round(mCircleSize / 2f) * 2;
         if (DEBUG) log("mCircleSize = " + mCircleSize + "px");

--- a/src/com/ceco/nougat/gravitybox/ModLockscreen.java
+++ b/src/com/ceco/nougat/gravitybox/ModLockscreen.java
@@ -532,10 +532,7 @@ public class ModLockscreen {
                     }
                 };
 
-                if (Utils.isSamsungRom()) {
-                    XposedHelpers.findAndHookMethod(CLASS_CARRIER_TEXT,
-                            classLoader, "updateCarrierText", Intent.class, carrierTextHook);
-                } else if (Utils.isOxygenOsRom()) {
+                if (Utils.isOxygenOsRom()) {
                     XposedHelpers.findAndHookMethod(CLASS_CARRIER_TEXT,
                             classLoader, "updateCarrierTextInternal", carrierTextHook);
                 } else {
@@ -546,71 +543,106 @@ public class ModLockscreen {
 
             // bottom actions
             try {
-                XposedHelpers.findAndHookMethod(CLASS_KG_BOTTOM_AREA_VIEW, classLoader,
-                        "updateLeftAffordanceIcon", new XC_MethodHook() {
-                    @Override
-                    protected void afterHookedMethod(final MethodHookParam param) throws Throwable {
-                        ImageView v = (ImageView) XposedHelpers.getObjectField(
-                                param.thisObject, "mLeftAffordanceView");
-                        if (mLeftActionHidden) {
-                            v.setVisibility(View.GONE);
-                        } else if (mLeftAction != null) {
-                            v.setVisibility(View.VISIBLE);
-                            if (mLeftActionDrawableOrig == null) {
-                                mLeftActionDrawableOrig = v.getDrawable();
+                if (!Utils.isSamsungRom()){
+                    XposedHelpers.findAndHookMethod(CLASS_KG_BOTTOM_AREA_VIEW, classLoader,
+                            "updateLeftAffordanceIcon", new XC_MethodHook() {
+                        @Override
+                        protected void afterHookedMethod(final MethodHookParam param) throws Throwable {
+                            ImageView v = (ImageView) XposedHelpers.getObjectField(
+                                    param.thisObject, "mLeftAffordanceView");
+                            if (mLeftActionHidden) {
+                                v.setVisibility(View.GONE);
+                            } else if (mLeftAction != null) {
+                                v.setVisibility(View.VISIBLE);
+                                if (mLeftActionDrawableOrig == null) {
+                                    mLeftActionDrawableOrig = v.getDrawable();
+                                }
+                                v.setImageDrawable(mLeftAction.getAppIcon());
+                                v.setContentDescription(mLeftAction.getAppName());
+                            } else if (mLeftActionDrawableOrig != null) {
+                                v.setImageDrawable(mLeftActionDrawableOrig);
+                                mLeftActionDrawableOrig = null;
                             }
-                            v.setImageDrawable(mLeftAction.getAppIcon());
-                            v.setContentDescription(mLeftAction.getAppName());
-                        } else if (mLeftActionDrawableOrig != null) {
-                            v.setImageDrawable(mLeftActionDrawableOrig);
-                            mLeftActionDrawableOrig = null;
                         }
-                    }
-                });
-    
-                XposedHelpers.findAndHookMethod(CLASS_KG_BOTTOM_AREA_VIEW, classLoader,
-                        "launchLeftAffordance", new XC_MethodHook() {
-                    @Override
-                    protected void beforeHookedMethod(final MethodHookParam param) throws Throwable {
-                        if (mLeftAction != null) {
-                            SysUiManagers.AppLauncher.startActivity(mContext, mLeftAction.getIntent());
-                            param.setResult(null);
-                        }
-                    }
-                });
-    
-                XposedHelpers.findAndHookMethod(CLASS_KG_BOTTOM_AREA_VIEW, classLoader,
-                        "updateCameraVisibility", new XC_MethodHook() {
-                    @Override
-                    protected void afterHookedMethod(final MethodHookParam param) throws Throwable {
-                        ImageView v = (ImageView) XposedHelpers.getObjectField(
-                                param.thisObject, "mCameraImageView");
-                        if (mRightActionHidden) {
-                            v.setVisibility(View.GONE);
-                        } else if (mRightAction != null) {
-                            v.setVisibility(View.VISIBLE);
-                            if (mRightActionDrawableOrig == null) {
-                                mRightActionDrawableOrig = v.getDrawable();
+                    });
+     
+                    XposedHelpers.findAndHookMethod(CLASS_KG_BOTTOM_AREA_VIEW, classLoader,
+                            "launchLeftAffordance", new XC_MethodHook() {
+                        @Override
+                        protected void beforeHookedMethod(final MethodHookParam param) throws Throwable {
+                            if (mLeftAction != null) {
+                                SysUiManagers.AppLauncher.startActivity(mContext, mLeftAction.getIntent());
+                                param.setResult(null);
                             }
-                            v.setImageDrawable(mRightAction.getAppIcon());
-                            v.setContentDescription(mRightAction.getAppName());
-                        } else if (mRightActionDrawableOrig != null) {
-                            v.setImageDrawable(mRightActionDrawableOrig);
-                            mRightActionDrawableOrig = null;
                         }
-                    }
-                });
+                    });
+                } else {
+                     XposedHelpers.findAndHookMethod(CLASS_KG_BOTTOM_AREA_VIEW, classLoader,
+                             "launchPhone", new XC_MethodHook() {
+                         @Override
+                         protected void beforeHookedMethod(final MethodHookParam param) throws Throwable {
+                             if (mLeftAction != null) {
+                                 SysUiManagers.AppLauncher.startActivity(mContext, mLeftAction.getIntent());
+                                 param.setResult(null);
+                             }
+                         }
+                     });
+             	}
+     
+                 XposedHelpers.findAndHookMethod(CLASS_KG_BOTTOM_AREA_VIEW, classLoader,
+                         "updateCameraVisibility", new XC_MethodHook() {
+                     @Override
+                     protected void afterHookedMethod(final MethodHookParam param) throws Throwable {
+                        ImageView v;
+                        if (Utils.isSamsungRom())
+                        {
+                             v = (ImageView) XposedHelpers.getObjectField(
+                                     param.thisObject, "mLeftAffordanceView");
+                             if (mLeftActionHidden) {
+                                 v.setVisibility(View.GONE);
+                             } else if (mLeftAction != null) {
+                                 v.setVisibility(View.VISIBLE);
+                                 if (mLeftActionDrawableOrig == null) {
+                                     mLeftActionDrawableOrig = v.getDrawable();
+                                 }
+                                 v.setImageDrawable(mLeftAction.getAppIcon());
+                                 v.setContentDescription(mLeftAction.getAppName());
+                             } else if (mLeftActionDrawableOrig != null) {
+                                 v.setImageDrawable(mLeftActionDrawableOrig);
+                                 mLeftActionDrawableOrig = null;
+                             }
+                             v = (ImageView) XposedHelpers.getObjectField(
+                             		param.thisObject, "mRightAffordanceView");
+                        } else {
+                             v = (ImageView) XposedHelpers.getObjectField(
+                                    param.thisObject, "mCameraImageView");
+                        }
+                         if (mRightActionHidden) {
+                             v.setVisibility(View.GONE);
+                         } else if (mRightAction != null) {
+                             v.setVisibility(View.VISIBLE);
+                             if (mRightActionDrawableOrig == null) {
+                                 mRightActionDrawableOrig = v.getDrawable();
+                             }
+                             v.setImageDrawable(mRightAction.getAppIcon());
+                             v.setContentDescription(mRightAction.getAppName());
+                         } else if (mRightActionDrawableOrig != null) {
+                             v.setImageDrawable(mRightActionDrawableOrig);
+                             mRightActionDrawableOrig = null;
+                         }
+                     }
+                 });
 
-                XposedBridge.hookAllMethods(XposedHelpers.findClass(CLASS_KG_BOTTOM_AREA_VIEW, classLoader),
-                        "launchCamera", new XC_MethodHook() {
-                    @Override
-                    protected void beforeHookedMethod(final MethodHookParam param) throws Throwable {
-                        if (mRightAction != null) {
-                            SysUiManagers.AppLauncher.startActivity(mContext, mRightAction.getIntent());
-                            param.setResult(null);
-                        }
-                    }
-                });
+                 XposedBridge.hookAllMethods(XposedHelpers.findClass(CLASS_KG_BOTTOM_AREA_VIEW, classLoader),
+                         "launchCamera", new XC_MethodHook() {
+                     @Override
+                     protected void beforeHookedMethod(final MethodHookParam param) throws Throwable {
+                         if (mRightAction != null) {
+                             SysUiManagers.AppLauncher.startActivity(mContext, mRightAction.getIntent());
+                             param.setResult(null);
+                         }
+                     }
+                 });
 
                 XposedHelpers.findAndHookMethod(CLASS_KG_BOTTOM_AREA_VIEW, classLoader,
                         "onVisibilityChanged", View.class, int.class, new XC_MethodHook() {
@@ -850,11 +882,7 @@ public class ModLockscreen {
     private static void updateCarrierText() {
         for (TextView tv : mCarrierTextViews) {
             try {
-                if (Utils.isSamsungRom()) {
-                    XposedHelpers.callMethod(tv, "updateCarrierText", (Intent) null);
-                } else {
-                    XposedHelpers.callMethod(tv, "updateCarrierText");
-                }
+                XposedHelpers.callMethod(tv, "updateCarrierText");
             } catch (Throwable t) {
                 XposedBridge.log(t);
             }

--- a/src/com/ceco/nougat/gravitybox/ModPowerMenu.java
+++ b/src/com/ceco/nougat/gravitybox/ModPowerMenu.java
@@ -418,7 +418,10 @@ public class ModPowerMenu {
                 replaceRecoveryMessage();
                 pm.reboot("recovery");
             } else if (mode == 3) {
-                pm.reboot("bootloader");
+                if (Utils.isSamsungRom())
+                    pm.reboot("download");
+                else 
+                    pm.reboot("bootloader");
             }
         }
 

--- a/src/com/ceco/nougat/gravitybox/ModStatusbarColor.java
+++ b/src/com/ceco/nougat/gravitybox/ModStatusbarColor.java
@@ -188,7 +188,7 @@ public class ModStatusbarColor {
         try {
             Object header = XposedHelpers.getObjectField(mPhoneStatusBar, "mHeader");
             ImageView settingsButton = (ImageView) XposedHelpers.getObjectField(
-                    header, Utils.isSamsungRom() ? "mSettingButton" : "mSettingsButton");
+                    header, "mSettingsButton");
             if (SysUiManagers.IconManager.isColoringEnabled()) {
                 settingsButton.setColorFilter(SysUiManagers.IconManager.getIconColor(),
                         PorterDuff.Mode.SRC_IN);

--- a/src/com/ceco/nougat/gravitybox/ModVolumePanel.java
+++ b/src/com/ceco/nougat/gravitybox/ModVolumePanel.java
@@ -119,11 +119,20 @@ public class ModVolumePanel {
             XposedBridge.hookAllConstructors(classVolumePanelCtrl, new XC_MethodHook() {
                 @Override
                 protected void afterHookedMethod(final MethodHookParam param) throws Throwable {
-                    String[] titles = (String[]) XposedHelpers.getObjectField(param.thisObject, "mStreamTitles");
-                    int idx = AudioManager.STREAM_NOTIFICATION;
-                    if (titles.length > idx && (titles[idx] == null || titles[idx].trim().isEmpty())) {
-                        Context ctx = (Context) XposedHelpers.getObjectField(param.thisObject, "mContext");
-                        titles[idx] = Utils.getGbContext(ctx).getString(R.string.notification_stream_name);
+                    if (Utils.isSamsungRom())
+                    {
+                       int[] titles = (int[]) XposedHelpers.getObjectField(param.thisObject, "STREAMTITLES");
+                       int idx = AudioManager.STREAM_NOTIFICATION;
+                       if (titles.length > idx && (titles[idx]==0)) {
+                          titles[idx] = (R.string.notification_stream_name);
+                       }
+                    } else {	
+                       String[] titles = (String[]) XposedHelpers.getObjectField(param.thisObject, "mStreamTitles");
+                       int idx = AudioManager.STREAM_NOTIFICATION;
+                       if (titles.length > idx && (titles[idx] == null || titles[idx].trim().isEmpty())) {
+                           Context ctx = (Context) XposedHelpers.getObjectField(param.thisObject, "mContext");
+                           titles[idx] = Utils.getGbContext(ctx).getString(R.string.notification_stream_name);
+                       }
                     }
                 }
             });

--- a/src/com/ceco/nougat/gravitybox/Utils.java
+++ b/src/com/ceco/nougat/gravitybox/Utils.java
@@ -294,7 +294,7 @@ public class Utils {
     public static boolean isSamsungRom() {
         if (mIsSamsumgRom != null) return mIsSamsumgRom;
 
-        mIsSamsumgRom = (new File("/system/framework/twframework.jar").isFile());
+        mIsSamsumgRom = (new File("/system/framework/twframework.jar").isFile() || new File("/system/framework/touchwiz.jar").isFile());
         return mIsSamsumgRom;
     }
 


### PR DESCRIPTION
Fixed isSamsungRom - twframework.jar no longer exists, added touchwiz.jar
Fixed Stream Tiles for Samsung. STREAMTITLES field is int[] and not String[]
Fixed coloring Samsung settings button - field mSettingsButton is same as AOSP.
Fixed Samsung reboot to download mode - added "downloaded" command
Fixed Samsung carrier text update - field updateCarrierText is same as AOSP.
Fixed manipulation of lockscreen shortcuts for Samsung roms
Fixed battery circle size for Samsung roms - new size is 14
Fixed battery mode not updating correctly on Samsung lockscrens - onBatteryLevelChanged method has additional args.