### PR TITLE
Remove second notification row from volume panel for Samsung devices

### DIFF
--- a/src/com/ceco/nougat/gravitybox/ModVolumePanel.java
+++ b/src/com/ceco/nougat/gravitybox/ModVolumePanel.java
@@ -107,7 +107,8 @@ public class ModVolumePanel {
                     mTimeout = prefs.getInt(
                             GravityBoxSettings.PREF_KEY_VOLUME_PANEL_TIMEOUT, 0);
 
-                    prepareNotificationRow();
+                    if (!Utils.isSamsungRom())
+                        prepareNotificationRow();
 
                     IntentFilter intentFilter = new IntentFilter();
                     intentFilter.addAction(GravityBoxSettings.ACTION_PREF_VOLUME_PANEL_MODE_CHANGED);


### PR DESCRIPTION
Fixed an issue where Samsung devices were showing a second notification row in the volume panel