### PR TITLE
Advanced power menu fix for some Samsung devices

### DIFF
--- a/src/com/ceco/nougat/gravitybox/ModPowerMenu.java
+++ b/src/com/ceco/nougat/gravitybox/ModPowerMenu.java
@@ -108,7 +108,7 @@ public class ModPowerMenu {
 
             //hides reboot confirmation screen for Samsung roms
             if (Utils.isSamsungRom()) {
-                XposedHelpers.findAndHookMethod(globalActionsClass, "initValueForCreate", boolean.class, new XC_MethodHook() {
+                XposedBridge.hookAllMethods(globalActionsClass, "initValueForCreate", new XC_MethodHook() {
                     @Override
                     protected void afterHookedMethod(MethodHookParam param) throws Throwable {
                         prefs.reload();

--- a/src/com/ceco/nougat/gravitybox/ModViewConfig.java
+++ b/src/com/ceco/nougat/gravitybox/ModViewConfig.java
@@ -46,16 +46,31 @@ public class ModViewConfig {
         try {
             if (prefs.getBoolean(GravityBoxSettings.PREF_KEY_FORCE_LTR_DIRECTION, false)) {
                 final Class<?> activityManagerSvcClass = XposedHelpers.findClass(CLASS_ACTIVITY_MANAGER_SERVICE, classLoader);
-                XposedHelpers.findAndHookMethod(activityManagerSvcClass, "updateConfigurationLocked", 
-                        Configuration.class, CLASS_ACTIVITY_RECORD, boolean.class, boolean.class,
-                        int.class, boolean.class, new XC_MethodHook() {
-                    @Override
-                    protected void beforeHookedMethod(final MethodHookParam param) throws Throwable {
-                        if (param.args[0] != null) {
-                            ((Configuration) param.args[0]).setLayoutDirection(null);
+                if (!Utils.isSamsungRom())
+                {
+                    XposedHelpers.findAndHookMethod(activityManagerSvcClass, "updateConfigurationLocked", 
+                            Configuration.class, CLASS_ACTIVITY_RECORD, boolean.class, boolean.class,
+                            int.class, boolean.class, new XC_MethodHook() {
+                        @Override
+                        protected void beforeHookedMethod(final MethodHookParam param) throws Throwable {
+                            if (param.args[0] != null) {
+                                ((Configuration) param.args[0]).setLayoutDirection(null);
+                            }
                         }
-                    }
-                });
+                    });
+                }
+                else {
+                    XposedHelpers.findAndHookMethod(activityManagerSvcClass, "updateConfigurationLocked", 
+                            Configuration.class, CLASS_ACTIVITY_RECORD, boolean.class, boolean.class,
+                            int.class, new XC_MethodHook() {
+                        @Override
+                        protected void beforeHookedMethod(final MethodHookParam param) throws Throwable {
+                            if (param.args[0] != null) {
+                                ((Configuration) param.args[0]).setLayoutDirection(null);
+                            }
+                        }
+                    });
+                }
             }
         } catch (Throwable t) {
             XposedBridge.log(t);


### PR DESCRIPTION
Fixed an issue where some Samsung devices have a different method declaration for power menu.
Fixed Force LTR view on Samsung devices.
