### PR TITLE
Quick app tile fix

### DIFF
--- a/src/com/ceco/oreo/gravitybox/quicksettings/QuickAppTile.java
+++ b/src/com/ceco/oreo/gravitybox/quicksettings/QuickAppTile.java
@@ -255,7 +255,6 @@ public class QuickAppTile extends QsTile {
         mAppSlots.add(new AppInfo(R.id.quickapp2));
         mAppSlots.add(new AppInfo(R.id.quickapp3));
         mAppSlots.add(new AppInfo(R.id.quickapp4));
-        updateAllApps();
     }
 
     private void updateAllApps() {
@@ -312,7 +311,8 @@ public class QuickAppTile extends QsTile {
             if (intent.hasExtra(GravityBoxSettings.EXTRA_QUICKAPP_SLOT4)) {
                 updateSubApp(3, intent.getStringExtra(GravityBoxSettings.EXTRA_QUICKAPP_SLOT4));
             }
-        } else if (intent.getAction().equals(Intent.ACTION_LOCKED_BOOT_COMPLETED)) {
+        } else if (intent.getAction().equals(Intent.ACTION_LOCKED_BOOT_COMPLETED)
+                || intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED)) {
             updateAllApps();
         }
     }


### PR DESCRIPTION
Fix for quick app tiles not initializing on Oneplus devices (OOS 5.0.1+).

This is the same fix as was needed for the lock screen app bar where custom apps aren't initialized on boot and before user encrypted storage is available. 

Note that I removed the call to updateAllApps() on line 258 as it appears to be redundant. Prior to this change, when gravitybox intializes on device boot it initializes all the tiles, then calls this update method, then when the ACTION_LOCKED_BOOT_COMPLETED or ACTION_BOOT_COMPLETED broadcast fires it would call the update method again. I found this because I was seeing the "App not found" error even after implementing my initial fix.