### PR TITLE
Couple fixes for file-based encrypted devices

### DIFF
--- a/src/com/ceco/oreo/gravitybox/ModLockscreen.java
+++ b/src/com/ceco/oreo/gravitybox/ModLockscreen.java
@@ -27,7 +27,6 @@ import com.ceco.oreo.gravitybox.managers.AppLauncher;
 import com.ceco.oreo.gravitybox.managers.KeyguardStateMonitor;
 import com.ceco.oreo.gravitybox.managers.SysUiManagers;
 
-import android.app.admin.DevicePolicyManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -212,9 +211,6 @@ public class ModLockscreen {
                     prepareCustomBackground();
                     prepareGestureDetector();
 
-                    DevicePolicyManager dpm = (DevicePolicyManager)
-                            mContext.getSystemService(Context.DEVICE_POLICY_SERVICE);
-
                     IntentFilter intentFilter = new IntentFilter();
                     intentFilter.addAction(GravityBoxSettings.ACTION_LOCKSCREEN_SETTINGS_CHANGED);
                     intentFilter.addAction(KeyguardImageService.ACTION_KEYGUARD_IMAGE_UPDATED);
@@ -222,9 +218,8 @@ public class ModLockscreen {
                     intentFilter.addAction(GravityBoxSettings.ACTION_PREF_LOCKSCREEN_BG_CHANGED);
                     intentFilter.addAction(GravityBoxSettings.ACTION_PREF_LOCKSCREEN_SHORTCUT_CHANGED);
 
-                    if (Utils.isOxygenOsRom()
-                            && dpm.getStorageEncryptionStatus() == DevicePolicyManager.ENCRYPTION_STATUS_ACTIVE_PER_USER) {
-                        if (DEBUG) log("File-based encryption enabled on Oneplus device. Using ACTION_BOOT_COMPLETED intent to init appbar.");
+                    if (Utils.isFileBasedEncrypted(mContext)) {
+                        if (DEBUG) log("File-based encryption enabled device. Using ACTION_BOOT_COMPLETED intent to init appbar.");
                         intentFilter.addAction(Intent.ACTION_BOOT_COMPLETED );
                     }
                     else {

--- a/src/com/ceco/oreo/gravitybox/Utils.java
+++ b/src/com/ceco/oreo/gravitybox/Utils.java
@@ -18,6 +18,7 @@ package com.ceco.oreo.gravitybox;
 import de.robv.android.xposed.XposedHelpers;
 import android.annotation.SuppressLint;
 import android.app.ActivityManager;
+import android.app.admin.DevicePolicyManager;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
@@ -43,6 +44,7 @@ import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
 import android.os.UserHandle;
+import android.os.UserManager;
 import android.os.Vibrator;
 import android.renderscript.Allocation;
 import android.renderscript.Allocation.MipmapControl;
@@ -99,6 +101,7 @@ public class Utils {
     private static Boolean mIsWifiOnly = null;
     private static String mDeviceCharacteristics = null;
     private static Boolean mIsOxygenOsRom = null;
+    private static Boolean mIsFileBasedEncrypted = null;
 
     // Device features
     private static Boolean mHasGeminiSupport = null;
@@ -291,6 +294,35 @@ public class Utils {
             mIsOxygenOsRom = version != null && !version.isEmpty() &&  !"0".equals(version); 
         }
         return mIsOxygenOsRom;
+    }
+    
+    public static boolean isFileBasedEncrypted(Context con) {
+    	if (mIsFileBasedEncrypted != null) return mIsFileBasedEncrypted;
+    	
+    	try {
+            DevicePolicyManager dpm = (DevicePolicyManager)
+                    con.getSystemService(Context.DEVICE_POLICY_SERVICE);
+            mIsFileBasedEncrypted = dpm.getStorageEncryptionStatus() == DevicePolicyManager.ENCRYPTION_STATUS_ACTIVE_PER_USER;
+            return mIsFileBasedEncrypted;
+    	} catch (Throwable t) {
+    		GravityBox.log(TAG, t);
+    		mIsFileBasedEncrypted = null;
+    		return false;
+    	}
+    }
+    
+    public static boolean isUserUnlocked(Context con){
+    	if (!isFileBasedEncrypted(con)) {
+    		return true;
+    	}
+    	
+    	try {
+	    	UserManager um = (UserManager) con.getSystemService(Context.USER_SERVICE);
+	    	return um.isUserUnlocked();
+    	} catch (Throwable t) {
+    		GravityBox.log(TAG, t);
+    		return true;   	
+    	}
     }
 
     public static boolean isParanoidRom() {

--- a/src/com/ceco/oreo/gravitybox/quicksettings/QsTileEventDistributor.java
+++ b/src/com/ceco/oreo/gravitybox/quicksettings/QsTileEventDistributor.java
@@ -29,7 +29,6 @@ import com.ceco.oreo.gravitybox.Utils;
 import com.ceco.oreo.gravitybox.managers.KeyguardStateMonitor;
 import com.ceco.oreo.gravitybox.managers.SysUiManagers;
 
-import android.app.admin.DevicePolicyManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -111,9 +110,6 @@ public class QsTileEventDistributor implements KeyguardStateMonitor.Listener {
     };
 
     private void prepareBroadcastReceiver() {
-        DevicePolicyManager dpm = (DevicePolicyManager)
-                mContext.getSystemService(Context.DEVICE_POLICY_SERVICE);
-
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(GravityBoxSettings.ACTION_PREF_QUICKSETTINGS_CHANGED);
         intentFilter.addAction(GravityBoxSettings.ACTION_PREF_EXPANDED_DESKTOP_MODE_CHANGED);
@@ -125,9 +121,8 @@ public class QsTileEventDistributor implements KeyguardStateMonitor.Listener {
         intentFilter.addAction(PhoneWrapper.ACTION_NETWORK_TYPE_CHANGED);
         intentFilter.addAction(Intent.ACTION_SCREEN_OFF);
 
-        if (Utils.isOxygenOsRom()
-                && dpm.getStorageEncryptionStatus() == DevicePolicyManager.ENCRYPTION_STATUS_ACTIVE_PER_USER) {
-            if (DEBUG) log("File-based encryption enabled on Oneplus device. Using ACTION_BOOT_COMPLETED intent to init QuickApp Tiles after unlock.");
+        if (Utils.isFileBasedEncrypted(mContext)) {
+            if (DEBUG) log("File-based encryption enabled device. Using ACTION_BOOT_COMPLETED intent to init QuickApp Tiles after unlock.");
             intentFilter.addAction(Intent.ACTION_BOOT_COMPLETED);
         }
         else {

--- a/src/com/ceco/oreo/gravitybox/quicksettings/QuickAppTile.java
+++ b/src/com/ceco/oreo/gravitybox/quicksettings/QuickAppTile.java
@@ -255,6 +255,12 @@ public class QuickAppTile extends QsTile {
         mAppSlots.add(new AppInfo(R.id.quickapp2));
         mAppSlots.add(new AppInfo(R.id.quickapp3));
         mAppSlots.add(new AppInfo(R.id.quickapp4));
+
+        if (!Utils.isUserUnlocked(mContext)) {
+        	if (DEBUG) log(getKey() + "User has not unlocked yet making credential protected storage unavailable. Skipping updateAllApps().");
+        } else {
+        	updateAllApps();
+        }
     }
 
     private void updateAllApps() {


### PR DESCRIPTION
Here's the fix I mentioned. As mentioned I made it apply to all devices instead of just OOS...
Changes:
- Making a few of the previous fixes for OxygenOS devices **apply to all oreo devices**.
- Added back call to updateAllApps() in QuickAppTile.java, however, now only called on fbe devices if the user is unlocked (storage available).
- Moved a few of the fbe related methods into the Utils class for reusability.
