### PR TITLE
Small visualizer improvements

### DIFF
--- a/src/com/ceco/oreo/gravitybox/visualizer/VisualizerController.java
+++ b/src/com/ceco/oreo/gravitybox/visualizer/VisualizerController.java
@@ -184,15 +184,14 @@ public class VisualizerController implements StatusBarStateChangedListener,
                     mView.setBitmap(bitmap, mDynamicColorEnabled);
                     if (DEBUG) log("updateMediaMetaData: artwork change detected; bitmap=" + bitmap);
                 }
+            } else {
+                mView.setBitmap(null, false);
+                mCurrentDrawableHash = 0;
             }
             if (SysUiManagers.BatteryInfoManager != null) {
                 SysUiManagers.BatteryInfoManager.registerListener(this);
             }
         } else {
-            mView.setArtist(null);
-            mView.setTitle(null);
-            mView.setBitmap(null, false);
-            mCurrentDrawableHash = 0;
             if (SysUiManagers.BatteryInfoManager != null) {
                 SysUiManagers.BatteryInfoManager.unregisterListener(this);
             }


### PR DESCRIPTION
The track info and palette color don't need to be cleared
when the track is stopped, only when they are not
available.