### PR TITLE
StatusbarSignalCluster: Fix (not fully) enabling data activity on Moto devices

### DIFF
--- a/src/com/ceco/nougat/gravitybox/StatusbarSignalCluster.java
+++ b/src/com/ceco/nougat/gravitybox/StatusbarSignalCluster.java
@@ -193,7 +193,13 @@ public class StatusbarSignalCluster implements BroadcastSubReceiver, IconManager
                         "config_hspap_data_distinguishable", true);
             }
         }
-
+        
+        // Activity arrows on Motorola devices should be enabled this way
+        if (prefs.getBoolean(GravityBoxSettings.PREF_KEY_SIGNAL_CLUSTER_DATA_ACTIVITY, false) && isMotoXtDevice()) {
+            resparam.res.setReplacement(ModStatusBar.PACKAGE_NAME, "bool", "config_enable_activity_on_wide_statusbar_icons", true);
+            resparam.res.setReplacement(ModStatusBar.PACKAGE_NAME, "bool", "config_enable_carrier_custom_activity_on_wide_quicksettings_icons", true);
+        }
+            
         String lteStyle = prefs.getString(GravityBoxSettings.PREF_KEY_SIGNAL_CLUSTER_LTE_STYLE, "DEFAULT");
         if (!lteStyle.equals("DEFAULT")) {
             resparam.res.setReplacement(ModStatusBar.PACKAGE_NAME, "bool", "config_show4GForLTE",


### PR DESCRIPTION
We shouldn't use GB's SignalActivity implementation in this case. Motorola's SystemUI can indicate data activity natively (their own NetworkController class has code for that, along with a set of drawables). Setting these booleans to true enables this functionality.

*Note: I haven't coded in Java for a long time so I have no clue on how to tell GravityBox to not use the custom SignalActivity class when running on a Motorola device. That's why I say it's not a full fix.