### PR TITLE
Make always-expanded notifications un-expandable

### DIFF
--- a/src/com/ceco/oreo/gravitybox/ModStatusBar.java
+++ b/src/com/ceco/oreo/gravitybox/ModStatusBar.java
@@ -875,11 +875,11 @@ public class ModStatusBar {
 
             // Expanded notifications
             try {
-                XposedHelpers.findAndHookMethod(expandableNotifRowClass, "isUserExpanded", new XC_MethodHook() {
+                XposedHelpers.findAndHookMethod(expandableNotifRowClass, "setSystemExpanded", boolean.class, new XC_MethodHook() {
                     @Override
                     protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
                         if (mNotifExpandAll) {
-                            param.setResult(true);
+                            param.args[0] = true;
                         }
                     }
                 });


### PR DESCRIPTION
Having notifications always expanded is nice, but it would be even nicer if it was possible to un-expand them sometimes. (Would be even better if they didn't restore to expanded when the drawer is hidden, but I haven't figured out how to do that.)