### PR TITLE
Turn off clock modification by default

### DIFF
--- a/GravityBox/src/main/java/com/ceco/q/gravitybox/ModStatusBar.java
+++ b/GravityBox/src/main/java/com/ceco/q/gravitybox/ModStatusBar.java
@@ -296,7 +296,7 @@ public class ModStatusBar {
             mLeftArea = mStatusBarView
                     .findViewById(res.getIdentifier("status_bar_left_side", "id", PACKAGE_NAME));
 
-            if (mPrefs.getBoolean(GravityBoxSettings.PREF_KEY_STATUSBAR_CLOCK_MASTER_SWITCH, true)) {
+            if (mPrefs.getBoolean(GravityBoxSettings.PREF_KEY_STATUSBAR_CLOCK_MASTER_SWITCH, false)) {
                 // find statusbar clock
                 TextView clock = mStatusBarView.findViewById(
                         res.getIdentifier("clock", "id", PACKAGE_NAME));

--- a/GravityBox/src/main/res/xml/gravitybox.xml
+++ b/GravityBox/src/main/res/xml/gravitybox.xml
@@ -882,7 +882,7 @@
                     android:key="pref_sb_clock_masterswitch"
                     android:title="@string/pref_masterswitch_title"
                     android:summary="@string/pref_sb_clock_masterswitch_summary"
-                    android:defaultValue="true" />
+                    android:defaultValue="false" />
 
                 <CheckBoxPreference 
                     android:key="pref_clock_hide"


### PR DESCRIPTION
EdXposed has an issue in treating inline methods, specially for getSmallTime(). This
causes ART to crash. To avoid this, turn off clock modification by default.