### PR TITLE
Add option to blur media artwork on lockscreen

### DIFF
--- a/GravityBox/src/main/java/com/ceco/r/gravitybox/GravityBoxSettings.java
+++ b/GravityBox/src/main/java/com/ceco/r/gravitybox/GravityBoxSettings.java
@@ -214,6 +214,8 @@ public class GravityBoxSettings extends GravityBoxActivity implements GravityBox
     public static final String PREF_KEY_LOCKSCREEN_BACKGROUND_OPACITY = "pref_lockscreen_bg_opacity";
     public static final String PREF_KEY_LOCKSCREEN_BACKGROUND_BLUR_EFFECT = "pref_lockscreen_bg_blur_effect";
     public static final String PREF_KEY_LOCKSCREEN_BACKGROUND_BLUR_INTENSITY = "pref_lockscreen_bg_blur_intensity";
+    public static final String PREF_KEY_LOCKSCREEN_MEDIA_BLUR_EFFECT = "pref_lockscreen_media_blur_effect";
+    public static final String PREF_KEY_LOCKSCREEN_MEDIA_BLUR_INTENSITY = "pref_lockscreen_media_blur_intensity";
     public static final String LOCKSCREEN_BG_DEFAULT = "default";
     public static final String LOCKSCREEN_BG_COLOR = "color";
     public static final String LOCKSCREEN_BG_IMAGE = "image";
@@ -900,6 +902,8 @@ public class GravityBoxSettings extends GravityBoxActivity implements GravityBox
             PREF_KEY_LOCKSCREEN_BACKGROUND_COLOR,
             PREF_KEY_LOCKSCREEN_BACKGROUND_BLUR_EFFECT,
             PREF_KEY_LOCKSCREEN_BACKGROUND_BLUR_INTENSITY,
+            PREF_KEY_LOCKSCREEN_MEDIA_BLUR_EFFECT,
+            PREF_KEY_LOCKSCREEN_MEDIA_BLUR_INTENSITY,
             PREF_KEY_LOCKSCREEN_BACKGROUND_OPACITY,
             PREF_KEY_LOCKSCREEN_QUICK_UNLOCK,
             PREF_KEY_LOCKSCREEN_PIN_LENGTH,

--- a/GravityBox/src/main/java/com/ceco/r/gravitybox/ModLockscreen.java
+++ b/GravityBox/src/main/java/com/ceco/r/gravitybox/ModLockscreen.java
@@ -248,6 +248,16 @@ public class ModLockscreen {
                         if (DEBUG)
                             log("finishUpdateMediaMetaData: showing custom background");
                     }
+                    if (hasMediaArtwork && state != StatusBarState.SHADE && mKgMonitor.isInteractive() &&
+                            mPrefs.getBoolean(GravityBoxSettings.PREF_KEY_LOCKSCREEN_MEDIA_BLUR_EFFECT, false)) {
+                        mCustomBg = BitmapUtils.blurBitmap(mContext, (Bitmap) param.args[2],
+                                mPrefs.getInt(GravityBoxSettings.PREF_KEY_LOCKSCREEN_MEDIA_BLUR_INTENSITY, 14));
+                        backDrop.animate().cancel();
+                        backDropBack.animate().cancel();
+                        backDropBack.setImageBitmap(mCustomBg);
+                        backDrop.setVisibility(View.VISIBLE);
+                        backDrop.animate().alpha(1f);
+                    }
                 }
             });
         } catch (Throwable t) {

--- a/GravityBox/src/main/res/values/strings.xml
+++ b/GravityBox/src/main/res/values/strings.xml
@@ -719,6 +719,9 @@
     <!-- Lockscreen: custom background blur effect -->
     <string name="pref_lockscreen_bg_blur_effect_title">Blur effect</string>
 
+    <!-- Lockscreen: custom media artwork blur effect -->
+    <string name="pref_lockscreen_media_blur_effect_title">Media artwork blur effect</string>
+
     <!-- Force overflow menu button -->
     <string name="pref_force_overflow_menu_button_title">Force overflow menu button</string>
     <string name="pref_force_overflow_menu_button_summary">Requires reboot</string>
@@ -783,6 +786,9 @@
 
     <!-- Blur effect intensity -->
     <string name="pref_lockscreen_bg_blur_intensity_title">Blur effect intensity</string>
+
+    <!-- Media artwork blur effect intensity -->
+    <string name="pref_lockscreen_media_blur_intensity_title">Media artwork blur effect intensity</string>
 
     <!-- Smart radio: independent delay for screen off power save event -->
     <string name="pref_smart_radio_screen_off_delay_title">Delayed power save</string>

--- a/GravityBox/src/main/res/xml/gravitybox.xml
+++ b/GravityBox/src/main/res/xml/gravitybox.xml
@@ -63,6 +63,23 @@
                 android:order="5"
                 android:dependency="pref_lockscreen_bg_blur_effect" />
 
+            <CheckBoxPreference
+                android:key="pref_lockscreen_media_blur_effect"
+                android:title="@string/pref_lockscreen_media_blur_effect_title"
+                android:defaultValue="false"
+                android:order="6"
+                android:dependency="pref_lockscreen_media_art_disable" />
+
+            <com.ceco.r.gravitybox.preference.SeekBarPreference
+                android:key="pref_lockscreen_media_blur_intensity"
+                android:title="@string/pref_lockscreen_media_blur_intensity_title"
+                minimum="1"
+                maximum="25"
+                interval="1"
+                android:defaultValue="14"
+                android:order="7"
+                android:dependency="pref_lockscreen_media_blur_effect" />
+
             <com.ceco.r.gravitybox.preference.SeekBarPreference
                 android:key="pref_lockscreen_bg_opacity"
                 android:title="@string/pref_lockscreen_bg_opacity_title"
@@ -227,7 +244,8 @@
             <CheckBoxPreference
                 android:key="pref_lockscreen_media_art_disable"
                 android:title="@string/pref_lockscreen_media_art_disable_title"
-                android:defaultValue="false" />
+                android:defaultValue="false"
+                android:disableDependentsState="true" />
 
         </PreferenceCategory>
 


### PR DESCRIPTION
I thought this might be a useful feature, originally wanted it for myself but may as well contribute. It adds a checkbox for enabling the artwork blur effect, and a slider for controlling the intensity. It also greys itself out if disable media art is checked.

It seems to work fine on my device (OP7Pro) but it's pretty much my first time doing anything Android related so hopefully I did this right.